### PR TITLE
Add CONTRIBUTORS.md file

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,20 @@
+Abel 'Akronix' Serrano Juste
+Ben Ennis
+Bram Pitoyo
+Chuck Harmston
+Cory Price
+Daniel Thorn
+Danny Coates
+Donovan Preston
+Erik Vold
+Ian Bicking
+Jared Hirsch
+John Gruen
+Kit Cambridge
+Mark Banner
+Michael R. Bernstein
+niharikak101
+Peter deHaan
+Sadika Sumanapala
+Wil Clouser
+YFdyh000


### PR DESCRIPTION
I generated this file manually using my script from https://github.com/mozilla-services/pageshot/issues/2380#issuecomment-286587433 &mdash; then I trimmed a couple of unwanted contributors (Bizarro and greenkeeperio-bot).

Not sure if the want to turn this into some ./bin/contributors script and hook into the Makefile so we can do this in a more automated way on each release (since we'll presumably have new contributors in the future).

Also noteworthy is that this only determines contributors based on Git commits, and doesn't include names of other people behind the scenes (such as our excellent UX team, UR team, legal team, l20n team, catering team, etc).

Fixes #2380 
