### PR TITLE
Exclude some pages from the screenshot context menu item

### DIFF
--- a/addon/webextension/background/main.js
+++ b/addon/webextension/background/main.js
@@ -63,7 +63,8 @@ window.main = (function () {
   browser.contextMenus.create({
     id: "create-screenshot",
     title: browser.i18n.getMessage("contextMenuLabel"),
-    contexts: ["page"]
+    contexts: ["page"],
+    documentUrlPatterns: ["<all_urls>"]
   }, () => {
     // Note: unlike most browser.* functions this one does not return a promise
     if (browser.runtime.lastError) {


### PR DESCRIPTION
This partially addresses @SoftVision-CosminMuntean's comment https://github.com/mozilla-services/screenshots/pull/2368#issuecomment-288721037

It'll prevent the context menu item from being added to excluded pages except the screenshots site itself by way of the default schemes in [match patterns](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Match_patterns).