### PR TITLE
Fix #2460, control Sentry with Telemetry pref

### DIFF
--- a/addon/webextension/background/analytics.js
+++ b/addon/webextension/background/analytics.js
@@ -70,5 +70,10 @@ window.analytics = (function () {
     });
   };
 
+  exports.getTelemetryPrefSync = function() {
+    catcher.watchPromise(exports.refreshTelemetryPref());
+    return !!telemetryPref;
+  };
+
   return exports;
 })();

--- a/addon/webextension/background/senderror.js
+++ b/addon/webextension/background/senderror.js
@@ -1,4 +1,4 @@
-/* globals browser, communication, makeUuid, Raven, catcher, auth */
+/* globals analytics, browser, communication, makeUuid, Raven, catcher, auth */
 
 window.errorpopup = (function () {
   let exports = {};
@@ -66,6 +66,10 @@ window.errorpopup = (function () {
   };
 
   exports.reportError = function (e) {
+    if (!analytics.getTelemetryPrefSync()) {
+      console.error("Telemetry disabled. Not sending critical error:", e);
+      return;
+    }
     let dsn = auth.getSentryPublicDSN();
     if (! dsn) {
       console.warn("Error:", e);


### PR DESCRIPTION
I kept getting undefined when I tried to use the `refreshTelemetryPref` promise inside `reportError` (maybe a devtools error?), so I went ahead and added a lazy updating synchronous pref checker.