### PR TITLE
delete data instead of device on delete-all

### DIFF
--- a/server/src/servershot.js
+++ b/server/src/servershot.js
@@ -539,8 +539,8 @@ Shot.deleteEverythingForDevice = function (backend, deviceId) {
     if (! ids.length) {
       ids = [deviceId];
     }
-    let deleteSql = `DELETE FROM devices WHERE
-     id IN (${db.markersForArgs(1, ids.length)})`;
+    let deleteSql = `DELETE FROM data WHERE
+     deviceid IN (${db.markersForArgs(1, ids.length)})`;
     return db.update(
       deleteSql,
       ids


### PR DESCRIPTION
A proposal for #2270

Instead of deleting the device just delete the data. (I'm not all that familiar with the server yet)

This approach doesn't require addon changes.