### PR TITLE
Start #2307, implement onboarding slideshow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ build/%.html: %.html
 	cp $< $@
 
 .PHONY: addon
-addon: npm set_backend set_sentry addon/webextension/manifest.json addon/install.rdf addon_locales addon/webextension/build/shot.js addon/webextension/build/inlineSelectionCss.js addon/webextension/build/raven.js addon/webextension/build/defaultSentryDsn.js
+addon: npm set_backend set_sentry addon/webextension/manifest.json addon/install.rdf addon_locales addon/webextension/build/shot.js addon/webextension/build/inlineSelectionCss.js addon/webextension/build/raven.js addon/webextension/build/defaultSentryDsn.js addon/webextension/build/onboardingCss.js addon/webextension/build/onboardingHtml.js
 
 EXPORT_MC_LOCATION := $(shell echo $${EXPORT_MC_LOCATION-../gecko})
 GIT_EXPORT_DIR := $(EXPORT_MC_LOCATION)/browser/extensions/screenshots
@@ -152,6 +152,14 @@ addon/webextension/build/shot.js: shared/shot.js
 addon/webextension/build/inlineSelectionCss.js: build/server/static/css/inline-selection.css
 	@mkdir -p $(@D)
 	./bin/build-scripts/css_to_js.py inlineSelectionCss $< > $@
+
+addon/webextension/build/onboardingCss.js: build/server/static/css/onboarding.css
+	@mkdir -p $(@D)
+	./bin/build-scripts/css_to_js.py onboardingCss $< > $@
+
+addon/webextension/build/onboardingHtml.js: addon/webextension/onboarding/slides.html
+	@mkdir -p $(@D)
+	./bin/build-scripts/css_to_js.py onboardingHtml $< > $@
 
 addon/webextension/build/raven.js: $(raven_source)
 	@mkdir -p $(@D)

--- a/addon/webextension/background/main.js
+++ b/addon/webextension/background/main.js
@@ -10,6 +10,14 @@ window.main = (function () {
   let manifest = browser.runtime.getManifest();
   let backend;
 
+  let hasSeenOnboarding;
+
+  browser.storage.local.get(["hasSeenOnboarding"]).then((result) => {
+    hasSeenOnboarding = !! result.hasSeenOnboarding;
+  }).catch((error) => {
+    console.error("Error getting hasSeenOnboarding:", error);
+  });
+
   exports.setBackend = function (newBackend) {
     backend = newBackend;
     backend = backend.replace(/\/*$/, "");
@@ -33,7 +41,7 @@ window.main = (function () {
 
   function toggleSelector(tab) {
     return analytics.refreshTelemetryPref()
-      .then(() => selectorLoader.toggle(tab.id))
+      .then(() => selectorLoader.toggle(tab.id, hasSeenOnboarding))
       .then(active => {
         setIconActive(active, tab.id);
         return active;
@@ -154,6 +162,11 @@ window.main = (function () {
       });
     }
   }));
+
+  communication.register("hasSeenOnboarding", () => {
+    hasSeenOnboarding = true;
+    catcher.watchPromise(browser.storage.set({hasSeenOnboarding}));
+  });
 
   return exports;
 })();

--- a/addon/webextension/background/selectorLoader.js
+++ b/addon/webextension/background/selectorLoader.js
@@ -7,7 +7,8 @@ window.selectorLoader = (function () {
   const standardScripts = [
     "catcher.js",
     "background/selectorLoader.js",
-    "selector/callBackground.js"
+    "selector/callBackground.js",
+    "selector/util.js"
   ];
 
   const selectorScripts = [
@@ -18,7 +19,6 @@ window.selectorLoader = (function () {
     "domainFromUrl.js",
     "build/inlineSelectionCss.js",
     "selector/documentMetadata.js",
-    "selector/util.js",
     "selector/ui.js",
     "selector/shooter.js",
     "selector/uicontrol.js"
@@ -72,7 +72,7 @@ window.selectorLoader = (function () {
 
   exports.unloadModules = function () {
     const watchFunction = catcher.watchFunction;
-    let allScripts = selectorScripts.concat(onboardingScripts);
+    let allScripts = standardScripts.concat(onboardingScripts).concat(selectorScripts);
     const moduleNames = allScripts.map((filename) =>
       filename.replace(/^.*\//, "").replace(/\.js$/, ""));
     moduleNames.reverse();

--- a/addon/webextension/background/selectorLoader.js
+++ b/addon/webextension/background/selectorLoader.js
@@ -40,7 +40,6 @@ window.selectorLoader = (function () {
   };
 
   exports.loadModules = function (tabId, hasSeenOnboarding) {
-    console.log("hasSeenOnboarding", hasSeenOnboarding);
     if (hasSeenOnboarding) {
       return executeModules(tabId, standardScripts.concat(selectorScripts));
     } else {

--- a/addon/webextension/manifest.json.template
+++ b/addon/webextension/manifest.json.template
@@ -57,7 +57,8 @@
   ],
   "web_accessible_resources": [
     "icons/cancel.svg",
-    "icons/download.svg"
+    "icons/download.svg",
+    "icons/icon-256.png"
   ],
   "permissions": [
     "activeTab",

--- a/addon/webextension/onboarding/slides.html
+++ b/addon/webextension/onboarding/slides.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <!-- onboarding.scss is automatically inserted here: -->
+    <style></style>
+    <!-- Here and in onboarding.scss use MOZ_EXTENSION/path to refer to local files -->
+  </head>
+  <body>
+    <div id="slide-overlay">
+      <!-- The current slide is set by having .active-slide-1, .active-slide-2, etc on #slide element: -->
+      <div id="slide-container" data-number-of-slides="4" class="active-slide-1">
+        <div class="slide slide-1">
+          <!-- Note: all images must be listed in manifest.json.template under web_accessible_resources -->
+          <header style="background-image: url('MOZ_EXTENSION/icons/icon-256.png');">
+          </header>
+          <h1><span data-l10n-id="tourHeaderOne">Firefox Screenshots</span><sup data-l10n-id="tourHeaderOneSuper">Beta</sup></h1>
+          <p data-l10n-id="tourBodyOne"></p>
+        </div>
+        <div class="slide slide-2">
+          <header></header>
+          <h1 data-l10n-id="tourHeaderTwo"></h1>
+          <p data-l10n-id="tourBodyTwo"></p>
+        </div>
+        <div class="slide slide-3">
+          <header></header>
+          <h1 data-l10n-id="tourHeaderThree"></h1>
+          <p data-l10n-id="tourBodyThree"></p>
+        </div>
+        <div class="slide slide-4">
+          <header></header>
+          <h1 data-l10n-id="tourHeaderFour"></h1>
+          <p data-l10n-id="tourBodyFour"></p>
+        </div>
+
+        <!-- Clickable elements should be buttons for accessibility -->
+        <button id="skip" data-l10n-id="tourSkip" tabindex=1>Skip</button>
+        <button id="prev" tabindex=2 data-l10n-label-id="tourPrevious">〈</button>
+        <button id="next" tabindex=3 data-l10n-label-id="tourNext">〉</button>
+        <button id="done" tabindex=4 data-l10n-id="tourDone">Done</button>
+        <div id="slide-status-container">
+          <button class="goto-slide goto-slide-1" data-number="1" tabindex=4><span></span></button>
+          <button class="goto-slide goto-slide-2" data-number="2" tabindex=5><span></span></button>
+          <button class="goto-slide goto-slide-3" data-number="3" tabindex=6><span></span></button>
+          <button class="goto-slide goto-slide-4" data-number="4" tabindex=7><span></span></button>
+        </div>
+        <!-- FIXME: Need to put in privacy / etc links -->
+      </div>
+    </div>
+  </body>
+</html>

--- a/addon/webextension/onboarding/slides.js
+++ b/addon/webextension/onboarding/slides.js
@@ -1,0 +1,168 @@
+/* globals catcher, onboardingHtml, onboardingCss, browser, util, shooter */
+window.slides = (function () {
+  let exports = {};
+
+  const { watchFunction } = catcher;
+
+  let iframe;
+  let doc;
+  let currentSlide = 1;
+  let numberOfSlides;
+  let callbacks;
+
+  exports.display = function (addCallbacks) {
+    if (iframe) {
+      throw new Error("Attemted to call slides.display() twice");
+    }
+    return new Promise((resolve, reject) => {
+      callbacks = addCallbacks;
+      // FIXME: a lot of this iframe logic is in ui.js; maybe move to util.js
+      iframe = document.createElement("iframe");
+      iframe.id = "firefox-screenshots-onboarding-iframe";
+      iframe.style.zIndex = "99999999999";
+      iframe.style.border = "none";
+      iframe.style.position = "fixed";
+      iframe.style.top = "0";
+      iframe.style.left = "0";
+      iframe.style.margin = "0";
+      iframe.scrolling = "no";
+      updateIframeSize();
+      let html = onboardingHtml.replace('<style></style>', `<style>${onboardingCss}</style>`);
+      html = html.replace(/MOZ_EXTENSION([^\"]+)/g, (match, filename) => {
+        return browser.extension.getURL(filename);
+      });
+      iframe.onload = catcher.watchFunction(() => {
+        let parsedDom = (new DOMParser()).parseFromString(
+          html,
+          "text/html"
+        );
+        doc = iframe.contentDocument;
+        doc.replaceChild(
+          doc.adoptNode(parsedDom.documentElement),
+          doc.documentElement
+        );
+        doc.addEventListener("keyup", onKeyUp, false);
+        localizeText(doc);
+        activateSlide(doc);
+        resolve();
+      });
+      document.body.appendChild(iframe);
+      iframe.focus();
+      window.addEventListener("resize", onResize, false);
+    });
+  };
+
+  exports.remove = exports.unload = function () {
+    window.removeEventListener("resize", onResize, false);
+    if (doc) {
+      doc.removeEventListener("keyup", onKeyUp, false);
+    }
+    util.removeNode(iframe);
+    iframe = doc = null;
+    currentSlide = 1;
+    numberOfSlides = undefined;
+    callbacks = undefined;
+  };
+
+  function localizeText(doc) {
+    let els = doc.querySelectorAll("[data-l10n-id]");
+    for (let el of els) {
+      let id = el.getAttribute("data-l10n-id");
+      let text = browser.i18n.getMessage(id);
+      el.textContent = text;
+    }
+    els = doc.querySelectorAll("[data-l10n-label-id]");
+    for (let el of els) {
+      let id = el.getAttribute("data-l10n-label-id");
+      let text = browser.i18n.getMessage(id);
+      el.setAttribute("aria-label", text);
+    }
+  }
+
+  function activateSlide(doc) {
+    numberOfSlides = parseInt(doc.querySelector("[data-number-of-slides]").getAttribute("data-number-of-slides"), 10);
+    doc.querySelector("#next").addEventListener("click", watchFunction(() => {
+      shooter.sendEvent("navigate-slide", "next");
+      next();
+    }), false);
+    doc.querySelector("#prev").addEventListener("click", watchFunction(() => {
+      shooter.sendEvent("navigate-slide", "prev");
+      prev();
+    }), false);
+    for (let el of doc.querySelectorAll(".goto-slide")) {
+      el.addEventListener("click", watchFunction((event) => {
+        shooter.sendEvent("navigate-slide", "goto");
+        let el = event.target;
+        let index = parseInt(el.getAttribute("data-number"), 10);
+        setSlide(index);
+      }), false);
+    }
+    doc.querySelector("#slide-overlay").addEventListener("click", watchFunction((event) => {
+      if (event.target.id == "slide-overlay") {
+        shooter.sendEvent("cancel-slides", "overlay");
+        callbacks.onEnd();
+      }
+    }), false);
+    doc.querySelector("#skip").addEventListener("click", watchFunction((event) => {
+      shooter.sendEvent("cancel-slides", "skip");
+      callbacks.onEnd();
+    }), false);
+    doc.querySelector("#done").addEventListener("click", watchFunction((event) => {
+      shooter.sendEvent("finish-slides", "done");
+      callbacks.onEnd();
+    }), false);
+    setSlide(1);
+  }
+
+  function next() {
+    setSlide(currentSlide + 1);
+  }
+
+  function prev() {
+    setSlide(currentSlide - 1);
+  }
+
+  const onResize = catcher.watchFunction(function () {
+    if (! iframe) {
+      console.warn("slides onResize called when iframe is not setup");
+      return;
+    }
+    updateIframeSize();
+  });
+
+  function updateIframeSize() {
+    iframe.style.height = window.innerHeight + "px";
+    iframe.style.width = window.innerWidth + "px";
+  }
+
+  const onKeyUp = catcher.watchFunction(function (event) {
+    console.log("got keyup event:", event.key, event.code);
+    if ((event.key || event.code) === "Escape") {
+      shooter.sendEvent("cancel-slides", "keyboard-escape");
+      callbacks.onEnd();
+    }
+  });
+
+  function setSlide(index) {
+    if (index < 1) {
+      index = 1;
+    }
+    if (index > numberOfSlides) {
+      index = numberOfSlides;
+    }
+    shooter.sendEvent("visited-slide", `slide-${index}`);
+    currentSlide = index;
+    let slideEl = doc.querySelector("#slide-container");
+    for (let i=1; i<=numberOfSlides; i++) {
+      let className = `active-slide-${i}`;
+      if (i == currentSlide) {
+        slideEl.classList.add(className);
+      } else {
+        slideEl.classList.remove(className);
+      }
+    }
+  }
+
+  return exports;
+})();
+null;

--- a/addon/webextension/onboarding/slides.js
+++ b/addon/webextension/onboarding/slides.js
@@ -136,7 +136,6 @@ window.slides = (function () {
   }
 
   const onKeyUp = catcher.watchFunction(function (event) {
-    console.log("got keyup event:", event.key, event.code);
     if ((event.key || event.code) === "Escape") {
       shooter.sendEvent("cancel-slides", "keyboard-escape");
       callbacks.onEnd();

--- a/bin/run-addon
+++ b/bin/run-addon
@@ -139,7 +139,9 @@ run_nodemon() {
     -w shared/shot.js \
     -w Makefile \
     -w static/css/inline-selection.scss \
+    -w static/css/onboarding.scss \
     -w static/css/partials/ \
+    -w addon/webextension/onboarding/slides.html \
     --on-change-only \
     --exec make addon &
   nodemon_pid=$!

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -134,6 +134,19 @@ Deprecated:
 1. Reloading a tab would emit `addon/cancel-shot/tab-reload`, now it emits `addon/cancel-shot/tab-load`
 1. Previously to the 54 launch there was `addon/start-shot/toolbar-pageshot-button` which was renamed to `addon/start-shot/toolbar-button`
 
+##### Onboarding metrics
+
+The onboarding slides have some events:
+
+1. Click on the next-slide button: `addon/navigate-slide/next`
+1. Click on the prev-slide button: `addon/navigate-slide/prev`
+1. Click on one of the dots to navigate to a specific slide: `addon/navigate-slide/goto`
+1. Cancel the slides by clicking on the background: `addon/cancel-slides/overlay`
+1. Cancel the slides by clicking on skip: `addon/cancel-slides/skip`
+1. Cancel the slides by hitting Escape: `addon/cancel-slides/keyboard-escape`
+1. Finish the slides by clicking on done: `addon/finish-slides/done`
+1. Visit a slide through any kind of navigation: `addon/visited-slide/slide-INDEX` (1-4)
+
 ##### Internal add-on events
 
 1. [x] Start an upload `addon/upload/started` with eventValue of Kb (1000 bytes)

--- a/locales/en-US/webextension.properties
+++ b/locales/en-US/webextension.properties
@@ -36,3 +36,7 @@ tourHeaderThree = As You Like it
 tourBodyThree = Save your cropped shots to the Web for easier sharing, or download them to your computer. You also can click on the My Shots button to find all the shots you’ve taken.
 tourHeaderFour = Capture Windows or Entire Pages
 tourBodyFour = Select the buttons in the upper right to capture the visible area in the window or to capture an entire page.
+tourSkip = Skip
+tourNext = Next Slide
+tourPrevious = Previous Slide
+tourDone = Done

--- a/static/css/onboarding.scss
+++ b/static/css/onboarding.scss
@@ -1,0 +1,197 @@
+@import "partials/variables";
+
+html,
+body {
+  margin: 0;
+  height: 100%;
+  width: 100%;
+  font-family: sans-serif;
+}
+
+$slide-width: 440px;
+$slide-height: 400px;
+$next-prev-size: 40px;
+$slide-status-color: $body-background-color;
+$status-inactive-size: 10px;
+$status-active-size: 14px;
+
+.slide-1,
+.slide-2,
+.slide-3,
+.slide-4,
+.slide-5 {
+  display: none;
+}
+
+.active-slide-1 .slide-1 {
+  display: block;
+}
+
+.active-slide-2 .slide-2 {
+  display: block;
+}
+
+.active-slide-3 .slide-3 {
+  display: block;
+}
+
+.active-slide-4 .slide-4 {
+  display: block;
+}
+
+.goto-slide {
+  border: 0;
+  background: transparent;
+  height: $status-active-size + 4;
+  vertical-align: middle;
+}
+
+.goto-slide > span {
+  display: inline-block;
+  height: $status-inactive-size;
+  width: $status-inactive-size;
+  background-color: $slide-status-color;
+  border-radius: $status-inactive-size / 2;
+  opacity: 0.7;
+}
+
+.goto-slide:hover > span {
+  opacity: 1;
+}
+
+@mixin active {
+  opacity: 1;
+  background-color: $slide-status-color;
+  height: $status-active-size;
+  width: $status-active-size;
+  border-radius: $status-active-size / 2;
+}
+
+.active-slide-1 .goto-slide-1 > span {
+  @include active;
+}
+
+.active-slide-2 .goto-slide-2 > span {
+  @include active;
+}
+
+.active-slide-3 .goto-slide-3 > span {
+  @include active;
+}
+
+.active-slide-4 .goto-slide-4 > span {
+  @include active;
+}
+
+%next-prev-button {
+  position: absolute;
+  display: inline-block;
+  height: $next-prev-size;
+  width: $next-prev-size;
+  border-radius: ($next-prev-size / 2);
+  border: 0;
+  top: 50%;
+  margin-top: - ($next-prev-size / 2);
+  text-align: center;
+}
+
+#prev {
+  @extend %next-prev-button;
+  left: 50%;
+  margin-left: - ($slide-width / 2) - ($next-prev-size / 2);
+}
+
+#next,
+#done {
+  @extend %next-prev-button;
+  left: 50%;
+  margin-left: ($slide-width / 2) - ($next-prev-size / 2);
+}
+
+#skip {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  margin-left: - ($slide-width / 2) + 20;
+  margin-top: ($slide-height / 2) + 10;
+  text-transform: uppercase;
+  background: none;
+  border: 0;
+  color: #fff;
+  font-size: 110%;
+  z-index: 10;
+}
+
+.active-slide-1 #prev {
+  display: none;
+}
+
+.active-slide-4 #next {
+  display: none;
+}
+
+#done {
+  display: none;
+  text-transform: uppercase;
+  font-size: 55%;
+}
+
+.active-slide-4 #done {
+  display: inline-block;
+}
+
+#slide-overlay {
+  background: rgba(0, 0, 0, 0.8);
+  height: 100%;
+  width: 100%;
+}
+
+#slide-container {
+  position: absolute;
+  background-color: $body-background-color;
+  top: 50%;
+  left: 50%;
+  width: $slide-width;
+  height: $slide-height;
+  margin-top: - ($slide-height / 2);
+  margin-left: - ($slide-width / 2);
+  // if .slide header doesn't have this radius too there are square corners:
+  border-radius: 5px;
+}
+
+#slide-status-container {
+  position: absolute;
+  top: $slide-height;
+  width: 100%;
+  text-align: center;
+  padding: 15px;
+}
+
+.slide p {
+  text-align: center;
+}
+
+h1 {
+  text-align: center;
+  font-size: 110%;
+  font-weight: normal;
+}
+
+h1 sup {
+  text-transform: uppercase;
+  font-size: 70%;
+  color: #fff;
+  background-color: rgb(0, 209, 230);
+  padding: 2px;
+  border-radius: 1px;
+  margin-left: 4px;
+}
+
+.slide header {
+  border-radius: 5px 5px 0 0;
+  height: $slide-height - 120;
+  background-color: #99f;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: contain;
+}


### PR DESCRIPTION
Not complete, but working.

This will open on every browser startup if you are using `./bin/run-addon`, since the flag for whether you have seen the onboarding is reset with each run.  Hot reloading doesn't reset the flag.

Followups: #2532 #2533 

There's code duplication between slides.js and ui.js, with a FIXME to acknowledge it, but I haven't made a ticket.  It feels safer to get this complete before refactoring these.

This leaves #2307 open in anticipation of full design.