### PR TITLE
Fix cancel button hover problems

### DIFF
--- a/static/css/inline-selection.scss
+++ b/static/css/inline-selection.scss
@@ -47,6 +47,8 @@ $overlay-z-index: 9999999999;
 .highlight-button-cancel {
   @extend .button;
   @extend .secondary;
+  // Overrides display: flex from .button, which causes hover problems
+  display: block;
   background: $very-light-grey url("MOZ_EXTENSION/icons/cancel.svg") center center no-repeat;
   background-size: 18px 18px;
   margin: 5px;


### PR DESCRIPTION
While looking at an unrelated bug, I noticed that the 'cancel' button in the selector overlay sometimes shows a flickering pointer (flickering between default and move states), and also sometimes misses clicks. Looking at the CSS, this was apparently also a problem for the download button; copying the fix over to the cancel button fixed the cancel button problems as well.