### PR TITLE
fix: Asks where to save the file when you download a selection

### DIFF
--- a/addon/webextension/background/main.js
+++ b/addon/webextension/background/main.js
@@ -150,7 +150,8 @@ window.main = (function () {
     const blob = new Blob([data], {type: "image/png"})
     return browser.downloads.download({
       url: URL.createObjectURL(blob),
-      filename: info.filename
+      filename: info.filename,
+      saveAs: true
     });
   });
 


### PR DESCRIPTION
This is a fix for #2550 

In this case, the download window is always displayed irrespective of preferences (even if the preferences are set to always download to a particular folder). 