### PR TITLE
Ensure correct initialization

### DIFF
--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -58,6 +58,11 @@ function shouldDisable() {
 }
 
 function handleStartup() {
+  // If the preference observer fires before startup completes, the URI won't
+  // be available yet, so just bail until startup has run.
+  if (!addonResourceURI) {
+    return;
+  }
   const webExtension = LegacyExtensionsUtils.getEmbeddedExtensionFor({
     id: ADDON_ID,
     resourceURI: addonResourceURI.QueryInterface(Ci.nsIFileURL)


### PR DESCRIPTION
Some Try jobs failed on the line that QI'd the URI to a FileURI.
Guarding against the preferences observer firing before startup fixes
those errors.