### PR TITLE
Remove embedded web extension in install manifest.

### DIFF
--- a/addon/install.rdf.template
+++ b/addon/install.rdf.template
@@ -14,7 +14,6 @@
     <em:type>2</em:type>
     <em:version>__VERSION__</em:version>
     <em:bootstrap>true</em:bootstrap>
-    <em:hasEmbeddedWebExtension>true</em:hasEmbeddedWebExtension>
     <em:homepageURL>https://pageshot.net/</em:homepageURL>
     <em:multiprocessCompatible>true</em:multiprocessCompatible>
   </Description>


### PR DESCRIPTION
`hasEmbeddedWebExtension` causes the embedded web extension to be parsed when the
bootstrapped extension is installed, which triggers a race condition in
existing Firefox code during startup on a clean profile between
AddonManager and devtools code.

Removing this is not an issue for Screenshots because it delays startup
of the embedded web extension until "sessionstore-windows-restored" is
observed anyway.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1356394 for more info.