### PR TITLE
Fix #2652, avoid error popups when selector is torn down during save

### DIFF
--- a/addon/webextension/catcher.js
+++ b/addon/webextension/catcher.js
@@ -1,4 +1,4 @@
-/* globals log */
+/* globals global */
 
 "use strict";
 
@@ -8,6 +8,8 @@ this.catcher = (function() {
   let handler;
 
   let queue = [];
+
+  let log = global.log;
 
   exports.unhandled = function(error, info) {
     log.error("Unhandled error:", error, info);

--- a/addon/webextension/selector/shooter.js
+++ b/addon/webextension/selector/shooter.js
@@ -1,6 +1,6 @@
-/* globals callBackground, documentMetadata, uicontrol, util, ui, catcher */
+/* globals global, documentMetadata, util, uicontrol, ui, catcher */
 /* globals XMLHttpRequest, window, location, alert, domainFromUrl, randomString */
-/* globals clipboard, document, setTimeout, location */
+/* globals document, setTimeout, location */
 
 "use strict";
 
@@ -12,6 +12,8 @@ this.shooter = (function() { // eslint-disable-line no-unused-vars
   let backend;
   let shot;
   let supportsDrawWindow;
+  const callBackground = global.callBackground;
+  const clipboard = global.clipboard;
 
   function regexpEscape(str) {
     // http://stackoverflow.com/questions/3115150/how-to-escape-regular-expression-special-characters-using-javascript
@@ -66,6 +68,7 @@ this.shooter = (function() { // eslint-disable-line no-unused-vars
     // isSaving indicates we're aleady in the middle of saving
     // we use a timeout so in the case of a failure the button will
     // still start working again
+    const uicontrol = global.uicontrol;
     if (isSaving) {
       return;
     }

--- a/addon/webextension/selector/uicontrol.js
+++ b/addon/webextension/selector/uicontrol.js
@@ -59,6 +59,7 @@ this.uicontrol = (function() {
   const SCROLL_BY_EDGE = 20;
 
   const { sendEvent } = shooter;
+  const log = global.log;
 
   function round10(n) {
     return Math.floor(n / 10) * 10;


### PR DESCRIPTION
Also bind several modules so that catcher works even after selectorLoader.unloadModules has been called

Note that an error is still signalled when there is a premature teardown, but only to the console

To reproduce the original error, run the server like this:

```
$ TEST_SLOW_RESPONSE=3000 ./bin/run-server
```

This gives enough time to switch tabs and hit Escape to close the selector.

There was another bug that caused the popup to stop displaying when there was an error that happened after teardown.  This also fixes that, while avoiding any popup for this particular situation.