### PR TITLE
Error handling improvements

### DIFF
--- a/addon/webextension/background/communication.js
+++ b/addon/webextension/background/communication.js
@@ -26,7 +26,7 @@ this.communication = (function() {
     } catch (e) {
       log.error(`Error in ${req.funcName}:`, e, e.stack);
       // FIXME: should consider using makeError from catcher here:
-      sendResponse({type: "error", message: e + ""});
+      sendResponse({type: "error", message: e + "", errorCode: e.errorCode, popupMessage: e.popupMessage});
       return;
     }
     if (result && result.then) {
@@ -34,7 +34,7 @@ this.communication = (function() {
         sendResponse({type: "success", value: concreteResult});
       }).catch((errorResult) => {
         log.error(`Promise error in ${req.funcName}:`, errorResult, errorResult && errorResult.stack);
-        sendResponse({type: "error", message: errorResult + ""});
+        sendResponse({type: "error", message: errorResult + "", errorCode: errorResult.errorCode, popupMessage: errorResult.popupMessage});
       });
       return true;
     }
@@ -66,7 +66,7 @@ this.communication = (function() {
     if (!error) {
       return false;
     }
-    return error.errorCode === "NO_RECEIVING_END" ||
+    return ('errorCode' in error && error.errorCode === "NO_RECEIVING_END") ||
       (!error.errorCode && error.message === "Could not establish connection. Receiving end does not exist.");
   }
 

--- a/addon/webextension/background/senderror.js
+++ b/addon/webextension/background/senderror.js
@@ -5,6 +5,8 @@
 this.senderror = (function() {
   let exports = {};
 
+  let manifest = browser.runtime.getManifest();
+
   // Do not show an error more than every ERROR_TIME_LIMIT milliseconds:
   const ERROR_TIME_LIMIT = 3000;
 
@@ -100,7 +102,7 @@ this.senderror = (function() {
     rest.stack = e.multilineStack || e.stack;
     Raven.captureException(exception, {
       logger: 'addon',
-      tags: {version: e.version, category: e.popupMessage},
+      tags: {version: manifest.version, category: e.popupMessage},
       message: exception.message,
       extra: rest
     });

--- a/addon/webextension/background/takeshot.js
+++ b/addon/webextension/background/takeshot.js
@@ -101,14 +101,13 @@ this.takeshot = (function() {
     return auth.authHeaders().then((headers) => {
       headers["content-type"] = "application/json";
       let body = JSON.stringify(shot.asJson());
-      let req = new Request(shot.jsonUrl, {
+      sendEvent("upload", "started", {eventValue: Math.floor(body.length / 1000)});
+      return fetch(shot.jsonUrl, {
         method: "PUT",
         mode: "cors",
         headers,
         body
       });
-      sendEvent("upload", "started", {eventValue: Math.floor(body.length / 1000)});
-      return fetch(req);
     }).then((resp) => {
       if (!resp.ok) {
         sendEvent("upload-failed", `status-${resp.status}`);
@@ -121,6 +120,7 @@ this.takeshot = (function() {
     }, (error) => {
       // FIXME: I'm not sure what exceptions we can expect
       sendEvent("upload-failed", "connection");
+      error.popupMessage = "CONNECTION_ERROR";
       throw error;
     });
   }

--- a/addon/webextension/catcher.js
+++ b/addon/webextension/catcher.js
@@ -1,6 +1,6 @@
-/* globals log */
-
 "use strict";
+
+var global = this;
 
 this.catcher = (function() {
   let exports = {};
@@ -8,6 +8,8 @@ this.catcher = (function() {
   let handler;
 
   let queue = [];
+
+  let log = global.log;
 
   exports.unhandled = function(error, info) {
     log.error("Unhandled error:", error, info);

--- a/addon/webextension/selector/callBackground.js
+++ b/addon/webextension/selector/callBackground.js
@@ -9,6 +9,12 @@ this.callBackground = function callBackground(funcName, ...args) {
     } else if (result.type === "error") {
       let exc = new Error(result.message);
       exc.name = "BackgroundError";
+      if ('errorCode' in result) {
+        exc.errorCode = result.errorCode;
+      }
+      if ('popupMessage' in result) {
+        exc.popupMessage = result.popupMessage;
+      }
       throw exc;
     } else {
       log.error("Unexpected background result:", result);

--- a/addon/webextension/selector/shooter.js
+++ b/addon/webextension/selector/shooter.js
@@ -110,7 +110,7 @@ this.shooter = (function() { // eslint-disable-line no-unused-vars
       const copied = clipboard.copy(url);
       return callBackground("openShot", { url, copied });
     }, (error) => {
-      if ('popupMessage' in error && (error.popupMessage = "REQUEST_ERROR" || error.popupMessage == 'CONNECTION_ERROR')) {
+      if ('popupMessage' in error && (error.popupMessage == "REQUEST_ERROR" || error.popupMessage == 'CONNECTION_ERROR')) {
         // The error has been signaled to the user, but unlike other errors (or
         // success) we should not abort the selection
         deactivateAfterFinish = false;

--- a/addon/webextension/selector/shooter.js
+++ b/addon/webextension/selector/shooter.js
@@ -1,6 +1,6 @@
-/* globals callBackground, documentMetadata, uicontrol, util, ui, catcher */
+/* globals global, documentMetadata, util, uicontrol, ui, catcher */
 /* globals XMLHttpRequest, window, location, alert, domainFromUrl, randomString */
-/* globals clipboard, document, setTimeout, location */
+/* globals document, setTimeout, location */
 
 "use strict";
 
@@ -12,6 +12,8 @@ this.shooter = (function() { // eslint-disable-line no-unused-vars
   let backend;
   let shot;
   let supportsDrawWindow;
+  const callBackground = global.callBackground;
+  const clipboard = global.clipboard;
 
   function regexpEscape(str) {
     // http://stackoverflow.com/questions/3115150/how-to-escape-regular-expression-special-characters-using-javascript
@@ -66,6 +68,7 @@ this.shooter = (function() { // eslint-disable-line no-unused-vars
     // isSaving indicates we're aleady in the middle of saving
     // we use a timeout so in the case of a failure the button will
     // still start working again
+    const uicontrol = global.uicontrol;
     if (isSaving) {
       return;
     }

--- a/addon/webextension/selector/uicontrol.js
+++ b/addon/webextension/selector/uicontrol.js
@@ -59,6 +59,7 @@ this.uicontrol = (function() {
   const SCROLL_BY_EDGE = 20;
 
   const { sendEvent } = shooter;
+  const log = global.log;
 
   function round10(n) {
     return Math.floor(n / 10) * 10;

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -640,6 +640,7 @@ app.put("/data/:id/:domain", function(req, res) {
   let failSometimes = config.testing.failSometimes;
   if (failSometimes && Math.floor(Math.random() * failSometimes)) {
     console.info("Artificially making request fail");
+    res.status(500);
     res.end();
     return;
   }


### PR DESCRIPTION
This handles a bunch of issues with error reporting:

* Make catcher work even after unloadModules
* Send addon version with errors
* Work around Raven bug with fetch()
* Add popupMessage for connection failure
* Pass more information about exceptions from background to workers
* Don't cancel the shot process in the case of certain errors