### PR TITLE
Fix #2790, allow JS to run even when ga-activation.js is suppressed

### DIFF
--- a/server/src/pages/shot/controller.js
+++ b/server/src/pages/shot/controller.js
@@ -35,7 +35,7 @@ exports.launch = function(data) {
       let testValue = model.shot.abTests[testName];
       if (testValue) {
         let shotFieldName = shotGaFieldForValue(testName, testValue);
-        if (shotFieldName) {
+        if (shotFieldName && window.abTests) {
           window.abTests[testName + "_shot"] = {
             gaField: shotFieldName,
             value: testValue


### PR DESCRIPTION
Unfortunately I couldn't reproduce the error, but there's lots of ways to configure uBlock, so I'm guessing I just didn't have it configured to block `ga-activation.js`

Still, this should protect against the reported error.