### PR TITLE
Fix #2792, make clip image.onload resilient

### DIFF
--- a/server/src/pages/shot/page.js
+++ b/server/src/pages/shot/page.js
@@ -2,5 +2,19 @@ const { Page } = require("../../reactruntime");
 
 exports.page = new Page({
   dir: __dirname,
-  viewModule: require("./view.js")
+  viewModule: require("./view.js"),
+  extraBodyJavascript: `
+(function () {
+  var el = document.getElementById("clipImage");
+  if (el) {
+    el.addEventListener("load", function () {
+      el.style.display = 'inline';
+      var spinner = document.getElementById("spinner");
+      if (spinner) {
+        spinner.style.display = 'none';
+      }
+    }, false);
+  }
+})();
+`
 });

--- a/server/src/pages/shot/view.js
+++ b/server/src/pages/shot/view.js
@@ -42,7 +42,10 @@ class Clip extends React.Component {
       console.warn("Somehow there's a shot without an image");
       return null;
     }
-    let node = <img style={{height: "auto", width: clip.image.dimensions.x + "px", maxWidth: "100%", display: this.state.imageDisplay}} ref="clipImage" src={ clip.image.url } alt={ clip.image.text } onLoad = { this.onImageLoaded.bind(this) } />;
+    let node = <img id="clipImage" style={{height: "auto", width: clip.image.dimensions.x + "px", maxWidth: "100%", display: this.state.imageDisplay}} ref="clipImage" src={ clip.image.url } alt={ clip.image.text } onLoad = { this.onImageLoaded.bind(this) } />;
+    // Note that in server/src/pages/shot/page.js there is also JavaScript defined
+    // that displays the image onload, as a backup to make sure the image always
+    // gets displayed even if the bundle doesn't load
     return <div ref="clipContainer" className="clip-container">
       <menu type="context" id="clip-image-context">
         <menuitem label="Copy Image Text" onClick={this.copyImageText.bind(this)} ></menuitem>
@@ -66,7 +69,7 @@ class Clip extends React.Component {
       return null;
     }
     return (
-      <div className="spinner">
+      <div id="spinner" className="spinner">
         <img src = {this.props.staticLink("/static/img/spinner.svg")} />
       </div>
     );

--- a/server/src/reactrender.js
+++ b/server/src/reactrender.js
@@ -58,6 +58,9 @@ if (window.controller) {
   window.initialModelLaunched = true;
 }
 `;
+      if (page.extraBodyJavascript) {
+        script += page.extraBodyJavascript;
+      }
       doc = addReactScripts(doc, script, req.cspNonce);
     }
     res.send(doc);

--- a/server/src/reactruntime.js
+++ b/server/src/reactruntime.js
@@ -106,7 +106,7 @@ exports.Page = class Page {
 };
 
 exports.Page.prototype.ATTRS = `
-dir viewModule noBrowserJavascript
+dir viewModule noBrowserJavascript extraBodyJavascript
 `.split(/\s+/g);
 
 if (typeof window !== "undefined") {


### PR DESCRIPTION
This duplicates some of the React logic that shows the clip image when it loads, but will run even if the bundle doesn't load or there's other Javascript errors.
Incidentally fixes #2651