### PR TITLE
use siteOrigin for /proxy urls

### DIFF
--- a/server/src/proxy-url.js
+++ b/server/src/proxy-url.js
@@ -2,7 +2,7 @@ const dbschema = require("./dbschema");
 const config = require("./config").getProperties();
 
 exports.createProxyUrl = function(req, url, hash) {
-  let base = `${req.protocol}://${config.contentOrigin}`;
+  let base = `${req.protocol}://${config.siteOrigin}`;
   let sig = dbschema.getKeygrip().sign(new Buffer(url, 'utf8'));
   let proxy = `${base}/proxy?url=${encodeURIComponent(url)}&sig=${encodeURIComponent(sig)}`;
   if (hash) {


### PR DESCRIPTION
The `contentOrigin` doesn't serve `/proxy` so we either need to make it do that or use `siteOrigin`. This does the latter.

fixes #2648