### PR TITLE
Fix #2842, if the /creating tab is closed open a new tab instead of updating the nonexistent tab

### DIFF
--- a/addon/webextension/background/takeshot.js
+++ b/addon/webextension/background/takeshot.js
@@ -47,7 +47,18 @@ this.takeshot = (function() {
       openedTab = tab;
       return uploadShot(shot);
     }).then(() => {
-      return browser.tabs.update(openedTab.id, {url: shot.viewUrl});
+      return browser.tabs.update(openedTab.id, {url: shot.viewUrl}).then(
+        null,
+        (error) => {
+          // FIXME: If https://bugzilla.mozilla.org/show_bug.cgi?id=1365718 is resolved,
+          // use the errorCode added as an additional check:
+          if ((/invalid tab id/i).test(error)) {
+            // This happens if the tab was closed before the upload completed
+            return browser.tabs.create({url: shot.viewUrl});
+          }
+          throw error;
+        }
+      );
     }).then(() => {
       return shot.viewUrl;
     }).catch((error) => {


### PR DESCRIPTION
To reproduce #2842:

    $ TEST_SLOW_RESPONSE=5000 ./bin/run-server

Then save a shot, close the /creating page, and previously you'd get an error (the shot was created, but the add-on would try to update the tab that had been closed).  With this change a new tab is opened in that case.