### PR TITLE
Fix #2734, make protocol configurable with EXPECT_PROTOCOL=https

### DIFF
--- a/server/src/config.js
+++ b/server/src/config.js
@@ -28,6 +28,13 @@ var conf = convict({
     env: "CONTENT_ORIGIN",
     arg: "contentOrigin"
   },
+  expectProtocol: {
+    doc: "Treat all incoming requests as using this protocol, instead of defaulting to http: or detecting from X-Forwarded-Proto",
+    format: String,
+    default: "",
+    env: "EXPECT_PROTOCOL",
+    arg: "expectProtocol"
+  },
   localhostSsl: {
     doc: "Turn on SSL on localhost, using ~/.localhost-ssl/*",
     format: Boolean,

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -179,6 +179,16 @@ function addHSTS(req, res) {
 
 addRavenRequestHandler(app);
 
+if (config.expectProtocol) {
+  if (!/^https?$/.test(config.expectProtocol)) {
+    throw new Error(`Error, bad EXPECT_PROTOCOL: ${config.expectProtocol}`);
+  }
+  app.use((req, res, next) => {
+    req.headers["x-forwarded-proto"] = config.expectProtocol;
+    next();
+  });
+}
+
 app.use((req, res, next) => {
   genUuid.generate(genUuid.V_RANDOM, function(err, uuid) {
     if (!err) {


### PR DESCRIPTION
I don't know if this will actually fix our problems, but from everything I can tell it should.  `req.protocol` is a getter, but its [logic is fairly simple](https://github.com/expressjs/express/blob/c087a45b9cc3eb69c777e260ee880758b6e03a40/lib/request.js#L306-L320).  `trust` is created [here](https://github.com/expressjs/express/blob/c087a45b9cc3eb69c777e260ee880758b6e03a40/lib/utils.js#L232-L251) with a `val` of `true`. 

Once applied we need to update our environmental config.