### PR TITLE
Fix #2931: disable DOM text capture by default

### DIFF
--- a/addon/webextension/buildSettings.js.template
+++ b/addon/webextension/buildSettings.js.template
@@ -1,5 +1,6 @@
 window.buildSettings = {
   defaultSentryDsn: process.env.SCREENSHOTS_SENTRY,
-  logLevel: process.env.SCREENSHOTS_LOG_LEVEL || "warn"
+  logLevel: process.env.SCREENSHOTS_LOG_LEVEL || "warn",
+  captureText: (process.env.SCREENSHOTS_CAPTURE_TEXT === "true")
 };
 null;

--- a/addon/webextension/selector/shooter.js
+++ b/addon/webextension/selector/shooter.js
@@ -1,5 +1,5 @@
 /* globals global, documentMetadata, util, uicontrol, ui, catcher */
-/* globals domainFromUrl, randomString */
+/* globals buildSettings, domainFromUrl, randomString */
 
 "use strict";
 
@@ -76,7 +76,10 @@ this.shooter = (function() { // eslint-disable-line no-unused-vars
       isSaving = null;
     }, 1000);
     selectedPos = selectedPos.asJson();
-    let captureText = util.captureEnclosedText(selectedPos);
+    let captureText = "";
+    if (buildSettings.captureText) {
+      captureText = util.captureEnclosedText(selectedPos);
+    }
     let dataUrl = screenshotPage(selectedPos);
     if (dataUrl) {
       shot.addClip({


### PR DESCRIPTION
Text capture can be enabled by setting the SCREENSHOTS_CAPTURE_TEXT env
var to 'true'.

With the env var set:

<img width="594" alt="screen shot 2017-05-31 at 3 13 22 pm" src="https://cloud.githubusercontent.com/assets/96396/26656844/a642a7a8-4615-11e7-9f30-e5db9efba422.png">

Without the env var set:

<img width="506" alt="screen shot 2017-05-31 at 3 14 23 pm" src="https://cloud.githubusercontent.com/assets/96396/26656845/a644a2ce-4615-11e7-95d9-3553a4856f5d.png">
