### PR TITLE
Consistent button label

### DIFF
--- a/addon/webextension/manifest.json.template
+++ b/addon/webextension/manifest.json.template
@@ -16,7 +16,7 @@
       "16": "icons/icon-16.svg",
       "32": "icons/icon-32.svg"
     },
-    "default_title": "__MSG_contextMenuLabel__",
+    "default_title": "Firefox Screenshots",
     "browser_style": false
   },
   "background": {

--- a/test/test.js
+++ b/test/test.js
@@ -221,7 +221,7 @@ describe("Test Screenshots", function() {
       getChromeElement(driver, By.id(SHOOTER_BUTTON_ID))
       .then((button) => button.getAttribute("label"))
       .then((label) => {
-        assert.equal(label, "Take a Screenshot");
+        assert.equal(label, "Firefox Screenshots");
       }),
       () => {
         driver.setContext(firefox.Context.CONTENT);


### PR DESCRIPTION
IIRC we decided not to localize the button label, but I hard-coded the string "Firefox Screenshots" in background/main, yet also localized it in the manifest (probably in a flurry of l10n edits).

Ian mentioned the browser test was inconsistent about the button label text; this is certainly why.

Browser test updated, seems to work consistently for me locally.