### PR TITLE
Fix #2933, allow for EXTRA_CONTENT_ORIGIN

### DIFF
--- a/server/src/config.js
+++ b/server/src/config.js
@@ -28,6 +28,13 @@ var conf = convict({
     env: "CONTENT_ORIGIN",
     arg: "contentOrigin"
   },
+  extraContentOrigin: {
+    doc: "If you have a second origin available for migration purposes",
+    format: String,
+    default: "",
+    env: "EXTRA_CONTENT_ORIGIN",
+    arg: "extraContentOrigin"
+  },
   expectProtocol: {
     doc: "Treat all incoming requests as using this protocol, instead of defaulting to http: or detecting from X-Forwarded-Proto",
     format: String,

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -199,10 +199,11 @@ app.use((req, res, next) => {
       } else {
         dsn = "";
       }
+      let extraContentOrigin = config.extraContentOrigin || "";
       req.cspNonce = uuid;
       res.header(
         "Content-Security-Policy",
-        `default-src 'self'; img-src 'self' www.google-analytics.com ${CONTENT_NAME} data:; script-src 'self' www.google-analytics.com 'nonce-${uuid}'; style-src 'self' 'unsafe-inline' https://code.cdn.mozilla.net; connect-src 'self' www.google-analytics.com ${dsn}; font-src https://code.cdn.mozilla.net; frame-ancestors 'none'; object-src 'none';`);
+        `default-src 'self'; img-src 'self' www.google-analytics.com ${CONTENT_NAME}${extraContentOrigin && ' ' + extraContentOrigin} data:; script-src 'self' www.google-analytics.com 'nonce-${uuid}'; style-src 'self' 'unsafe-inline' https://code.cdn.mozilla.net; connect-src 'self' www.google-analytics.com ${dsn}; font-src https://code.cdn.mozilla.net; frame-ancestors 'none'; object-src 'none';`);
       res.header("X-Frame-Options", "DENY");
       res.header("X-Content-Type-Options", "nosniff");
       addHSTS(req, res);


### PR DESCRIPTION
This adds a new configuration, EXTRA_CONTENT_ORIGIN, which is added to the CSP
This is intended just for migrating the pageshot.net content origin