### PR TITLE
Fix #3024, update terms and privacy language

### DIFF
--- a/locales/en-US/webextension.properties
+++ b/locales/en-US/webextension.properties
@@ -46,7 +46,7 @@ tourDone = Done
 # Do not translate {termsAndPrivacyNoticeTermsLink} and
 # {termsAndPrivacyNoticyPrivacyLink}. They're placeholders replaced by links
 # using the corresponding translated strings as text.
-termsAndPrivacyNoticeCloudServices = By using Firefox Screenshots, you agree to the Firefox Cloud Services {termsAndPrivacyNoticeTermsLink} and {termsAndPrivacyNoticePrivacyLink}.
+termsAndPrivacyNotice2 = By using Firefox Screenshots, you agree to our {termsAndPrivacyNoticeTermsLink} and {termsAndPrivacyNoticePrivacyLink}.
 # This string is used as the text for a link in termsAndPrivacyNoticeCloudServices
 termsAndPrivacyNoticeTermsLink = Terms
 # This string is used as the text for a link in termsAndPrivacyNoticeCloudServices


### PR DESCRIPTION
Turns out `termsAndPrivacyNotice` was the original name of this string, so opted to increment a counter at the end :-P