### PR TITLE
Guard access of this.save when un-disabling the save button

### DIFF
--- a/addon/webextension/selector/ui.js
+++ b/addon/webextension/selector/ui.js
@@ -564,6 +564,11 @@ this.ui = (function() { // eslint-disable-line no-unused-vars
     },
 
     clearSaveDisabled() {
+      if (!this.save) {
+        // Happens if we try to remove the disabled status after the worker
+        // has been shut down
+        return;
+      }
       this.save.removeAttribute("disabled");
     },
 


### PR DESCRIPTION
This can happen after the worker has been torn down, and this.save isn't defined