### PR TITLE
New startupcache approach

### DIFF
--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -1,3 +1,4 @@
+/* globals ADDON_DISABLE */
 const OLD_ADDON_PREF_NAME = "extensions.jid1-NeEaf3sAHdKHPA@jetpack.deviceIdInfo";
 const OLD_ADDON_ID = "jid1-NeEaf3sAHdKHPA@jetpack";
 const ADDON_ID = "screenshots@mozilla.org";
@@ -59,7 +60,10 @@ const appStartupObserver = {
 }
 
 const APP_STARTUP = 1;
+let startupReason;
+
 function startup(data, reason) { // eslint-disable-line no-unused-vars
+  startupReason = reason;
   if (reason === APP_STARTUP) {
     appStartupObserver.register();
   } else {
@@ -78,7 +82,7 @@ function shutdown(data, reason) { // eslint-disable-line no-unused-vars
     resourceURI: addonResourceURI
   });
   if (webExtension.started) {
-    stop(webExtension);
+    stop(webExtension, reason);
   }
 }
 
@@ -103,12 +107,12 @@ function handleStartup() {
   if (!shouldDisable() && !webExtension.started) {
     start(webExtension);
   } else if (shouldDisable()) {
-    stop(webExtension);
+    stop(webExtension, ADDON_DISABLE);
   }
 }
 
 function start(webExtension) {
-  webExtension.startup().then((api) => {
+  webExtension.startup(startupReason).then((api) => {
     api.browser.runtime.onMessage.addListener(handleMessage);
   }).catch((err) => {
     // The startup() promise will be rejected if the webExtension was
@@ -121,8 +125,8 @@ function start(webExtension) {
   });
 }
 
-function stop(webExtension) {
-  webExtension.shutdown();
+function stop(webExtension, reason) {
+  webExtension.shutdown(reason);
 }
 
 function handleMessage(msg, sender, sendReply) {

--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -60,13 +60,24 @@ const appStartupObserver = {
   }
 }
 
-const cacheBustReasons = [ADDON_INSTALL, ADDON_UPGRADE, ADDON_DOWNGRADE];
+const APP_STARTUP = 1;
+const APP_SHUTDOWN = 2;
+const ADDON_ENABLE = 3;
+const ADDON_DISABLE = 4;
+const ADDON_INSTALL = 5;
+const ADDON_UNINSTALL = 6;
+const ADDON_UPGRADE = 7;
+const ADDON_DOWNGRADE = 8;
+const cacheBustReasons = [ADDON_INSTALL, ADDON_UNINSTALL, ADDON_UPGRADE, ADDON_DOWNGRADE];
+
 let startupReason;
+let shutdownReason;
 
 // Clear the startup cache manually until bug 1372750 is fixed.
 function maybeClearAddonCache() {
   let result = Promise.resolve();
-  if (startupReason && cacheBustReasons.includes(startupReason)) {
+  if ((startupReason && cacheBustReasons.includes(startupReason)) ||
+     (shutdownReason && cacheBustReasons.includes(shutdownReason))) {
     result = ExtensionParent.StartupCache.clearAddonData(ADDON_ID);
   }
   return result;
@@ -86,14 +97,17 @@ function startup(data, reason) { // eslint-disable-line no-unused-vars
 }
 
 function shutdown(data, reason) { // eslint-disable-line no-unused-vars
+  shutdownReason = reason;
   prefObserver.unregister();
   const webExtension = LegacyExtensionsUtils.getEmbeddedExtensionFor({
     id: ADDON_ID,
     resourceURI: addonResourceURI
   });
-  if (webExtension.started) {
-    stop(webExtension);
-  }
+  maybeClearAddonCache().then(() => {
+    if (webExtension.started) {
+      stop(webExtension);
+    }
+  });
 }
 
 function install(data, reason) {} // eslint-disable-line no-unused-vars

--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -16,8 +16,6 @@ XPCOMUtils.defineLazyModuleGetter(this, "Services",
                                   "resource://gre/modules/Services.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "LegacyExtensionsUtils",
                                   "resource://gre/modules/LegacyExtensionsUtils.jsm");
-XPCOMUtils.defineLazyModuleGetter(this, "ExtensionParent",
-                                  "resource://gre/modules/ExtensionParent.jsm");
 
 let addonResourceURI;
 let appStartupDone;
@@ -61,30 +59,7 @@ const appStartupObserver = {
 }
 
 const APP_STARTUP = 1;
-const APP_SHUTDOWN = 2;
-const ADDON_ENABLE = 3;
-const ADDON_DISABLE = 4;
-const ADDON_INSTALL = 5;
-const ADDON_UNINSTALL = 6;
-const ADDON_UPGRADE = 7;
-const ADDON_DOWNGRADE = 8;
-const cacheBustReasons = [ADDON_INSTALL, ADDON_UNINSTALL, ADDON_UPGRADE, ADDON_DOWNGRADE];
-
-let startupReason;
-let shutdownReason;
-
-// Clear the startup cache manually until bug 1372750 is fixed.
-function maybeClearAddonCache() {
-  let result = Promise.resolve();
-  if ((startupReason && cacheBustReasons.includes(startupReason)) ||
-     (shutdownReason && cacheBustReasons.includes(shutdownReason))) {
-    result = ExtensionParent.StartupCache.clearAddonData(ADDON_ID);
-  }
-  return result;
-}
-
 function startup(data, reason) { // eslint-disable-line no-unused-vars
-  startupReason = reason;
   if (reason === APP_STARTUP) {
     appStartupObserver.register();
   } else {
@@ -97,17 +72,14 @@ function startup(data, reason) { // eslint-disable-line no-unused-vars
 }
 
 function shutdown(data, reason) { // eslint-disable-line no-unused-vars
-  shutdownReason = reason;
   prefObserver.unregister();
   const webExtension = LegacyExtensionsUtils.getEmbeddedExtensionFor({
     id: ADDON_ID,
     resourceURI: addonResourceURI
   });
-  maybeClearAddonCache().then(() => {
-    if (webExtension.started) {
-      stop(webExtension);
-    }
-  });
+  if (webExtension.started) {
+    stop(webExtension);
+  }
 }
 
 function install(data, reason) {} // eslint-disable-line no-unused-vars
@@ -128,13 +100,11 @@ function handleStartup() {
     resourceURI: addonResourceURI
   });
 
-  maybeClearAddonCache().then(() => {
-    if (!shouldDisable() && !webExtension.started) {
-      start(webExtension);
-    } else if (shouldDisable()) {
-      stop(webExtension);
-    }
-  });
+  if (!shouldDisable() && !webExtension.started) {
+    start(webExtension);
+  } else if (shouldDisable()) {
+    stop(webExtension);
+  }
 }
 
 function start(webExtension) {


### PR DESCRIPTION
This reverts the previous startup cache attempt.  It addresses changes useful when https://bugzilla.mozilla.org/show_bug.cgi?id=1372750 lands, and also requires https://bugzilla.mozilla.org/show_bug.cgi?id=1373749

In a landing patch we'll change the cache schema version to fix #3027 

The [v10-release](https://github.com/mozilla-services/screenshots/tree/v10-release) branch contains these changes and a version bump to 10.3.0.