### PR TITLE
Fix #2516; Tweak flex syntax so shot pages work on IE 11

### DIFF
--- a/static/css/frame.scss
+++ b/static/css/frame.scss
@@ -227,7 +227,7 @@
 
 .clip-container {
   @include flex-container(row, center, center);
-  flex: 1;
+  flex: 0 auto;
   margin: 20px auto;
   max-width: 90%;
 }


### PR DESCRIPTION
See #2516 for details. This seems to not break anything and fix the IE bug. Note that modern.ie does still exist, for verifying the fix.