### PR TITLE
Disallow package-lock for npm5 fsevents compatibility

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
See https://github.com/mapbox/node-pre-gyp/issues/298 for details.