### PR TITLE
Fix Bug 1373614, stop the embedded WebExtension unconditionally

### DIFF
--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -81,9 +81,7 @@ function shutdown(data, reason) { // eslint-disable-line no-unused-vars
     id: ADDON_ID,
     resourceURI: addonResourceURI
   });
-  if (webExtension.started) {
-    stop(webExtension, reason);
-  }
+  stop(webExtension, reason);
 }
 
 function install(data, reason) {} // eslint-disable-line no-unused-vars


### PR DESCRIPTION
In test conditions, when the browser is started and stopped very quickly, sometimes we didn't shut down the WebExtension because it hadn't fully started.
r=kmag (in https://bugzilla.mozilla.org/show_bug.cgi?id=1373614)