### PR TITLE
Fix #2981, sanitize download filename more fully

### DIFF
--- a/shared/shot.js
+++ b/shared/shot.js
@@ -351,7 +351,7 @@ class AbstractShot {
   get filename() {
     let filenameTitle = this.title;
     let date = new Date(this.createdDate);
-    filenameTitle = filenameTitle.replace(/[\/!@&*.|\n\r\t]/g, " ");
+    filenameTitle = filenameTitle.replace(/[:\\<>\/!@&*.|\n\r\t]/g, " ");
     filenameTitle = filenameTitle.replace(/\s{1,4000}/g, " ");
     let clipFilename = `Screenshot-${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()} ${filenameTitle}`;
     const clipFilenameBytesSize = clipFilename.length * 2; // JS STrings are UTF-16


### PR DESCRIPTION
This adds : (important on Windows), \, <, and > to the blacklist.
Followup in #3083