### PR TITLE
Fix #3039, update tests for full-page preview

### DIFF
--- a/addon/webextension/selector/uicontrol.js
+++ b/addon/webextension/selector/uicontrol.js
@@ -363,7 +363,7 @@ this.uicontrol = (function() {
    */
 
   let dataUrl;
-  
+
   stateHandlers.previewing = {
     start() {
       dataUrl = shooter.screenshotPage(selectedPos);

--- a/test/test.js
+++ b/test/test.js
@@ -19,6 +19,7 @@ const path = require("path");
 const SHOOTER_BUTTON_ID = "screenshots_mozilla_org-browser-action";
 const SLIDE_IFRAME_ID = "firefox-screenshots-onboarding-iframe";
 const PRESELECTION_IFRAME_ID = "firefox-screenshots-preselection-iframe";
+const PREVIEW_IFRAME_ID = "firefox-screenshots-preview-iframe";
 const backend = "http://localhost:10080";
 
 function addAddonToDriver(driver, location) {
@@ -240,10 +241,24 @@ describe("Test Screenshots", function() {
       return focusIframe(driver, PRESELECTION_IFRAME_ID);
     }).then(() => {
       return driver.wait(
-        until.elementLocated(By.css(".visible")));
+        until.elementLocated(By.css(".visible"))
+      );
     }).then((visibleButton) => {
+      visibleButton.click();
+      return driver.switchTo().defaultContent();
+    }).then(() => {
+      return driver.wait(
+        until.elementLocated(By.id(PREVIEW_IFRAME_ID))
+      );
+    }).then(() => {
+      return focusIframe(driver, PREVIEW_IFRAME_ID);
+    }).then(() => {
+      return driver.wait(
+        until.elementLocated(By.css(".preview-button-save"))
+      );
+    }).then((saveButton) => {
       return expectCreatedShot(driver, () => {
-        visibleButton.click();
+        saveButton.click();
       });
     }).then((shotUrl) => {
       assert(shotUrl.startsWith(backend), `Got url ${shotUrl} that doesn't start with ${backend}`);


### PR DESCRIPTION
The tests expected that a click on .visible would immediately upload the screenshot. This patch changes it to click the save button before expecting upload.