### PR TITLE
Add locales to Docker app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:7
 
 COPY package.json /app/
+COPY locales /app/locales
 COPY build/server /app/build/server
 COPY build/static /app/build/static
 COPY build/shared /app/build/shared


### PR DESCRIPTION
@relud Maybe this is why the locales are missing from dev right now?

The server code in /server/src/l10n.js looks for the locales at "../../locales", which I think corresponds to the one-liner added to the Dockerfile.

Not sure how to test this, as I haven't gotten the Docker image working locally.