### PR TITLE
Fix homePageCapturePageDescription for en-US

### DIFF
--- a/locales/en-US/server.ftl
+++ b/locales/en-US/server.ftl
@@ -31,7 +31,7 @@ homePageCaptureRegion = Capture a Region
 // Note: Screenshots is an abbreviation for Firefox Screenshots, and should not be translated.
 homePageCaptureRegionDescription = Click and drag to select the area you want to capture. Or just hover and click — Screenshots will select the area for you. Like what you see? Select Save to access your screenshot online or the down arrow button to download it to your computer.
 homePageCapturePage = Capture a Page
-homePageCapturePageDescription = Use the buttons in the upper right to capture full pages. The Save Visible button will capture the area you can view without scrolling, and the Save Full Page will capture everything on the page.
+homePageCapturePageDescription = Use the buttons in the upper right to capture full pages. The Save Visible button will capture the area you can view without scrolling, and Save Full Page will capture everything on the page.
 homePageSaveShare = Save and Share
 // Note: Screenshots is an abbreviation for Firefox Screenshots, and should not be translated.
 homePageSaveShareDescription = When you take a shot, Firefox posts your screenshot to your online Screenshots library and copies the link to your clipboard. We automatically store your screenshot for two weeks, but you can delete shots at any time or change the expiration date to keep them in your library for longer.


### PR DESCRIPTION
Either is missing a "button", or it should not have a "the" before. Since there are already two "button" in the string, I opted for removing "the".