### PR TITLE
Fix #2917, update browser test to match refactoring in mozilla-central

### DIFF
--- a/test/addon/browser_screenshots_ui_check.js
+++ b/test/addon/browser_screenshots_ui_check.js
@@ -9,7 +9,7 @@ function checkElements(expectPresent, l) {
 add_task(async function() {
   await promiseScreenshotsEnabled();
 
-  registerCleanupFunction(async function () {
+  registerCleanupFunction(async function() {
     await promiseScreenshotsReset();
   });
 

--- a/test/addon/browser_screenshots_ui_check.js
+++ b/test/addon/browser_screenshots_ui_check.js
@@ -6,14 +6,14 @@ function checkElements(expectPresent, l) {
   }
 }
 
-add_task(function*() {
-  yield promiseScreenshotsEnabled();
+add_task(async function() {
+  await promiseScreenshotsEnabled();
 
-  registerCleanupFunction(function* () {
-    yield promiseScreenshotsReset();
+  registerCleanupFunction(async function () {
+    await promiseScreenshotsReset();
   });
 
-  yield BrowserTestUtils.waitForCondition(
+  await BrowserTestUtils.waitForCondition(
     () => document.getElementById("screenshots_mozilla_org-browser-action"),
     "Screenshots button should be present", 100, 100);
 


### PR DESCRIPTION
Currently, when exporting the addon to Firefox, an upstream refactoring (from generator functions to async/await syntax) gets reversed. Fixing this in master will reduce the number of potential export gotchas by one. (Maybe this should be landed in the export branch instead, for now?)