### PR TITLE
Gracefully handle toolbar button mashing

### DIFF
--- a/addon/webextension/background/selectorLoader.js
+++ b/addon/webextension/background/selectorLoader.js
@@ -64,6 +64,11 @@ this.selectorLoader = (function() {
   let loadingTabs = new Set();
 
   exports.loadModules = function(tabId, hasSeenOnboarding) {
+    // Sometimes loadModules is called when the tab is already loading.
+    // Adding a check here seems to help avoid catastrophe.
+    if (loadingTabs.has(tabId)) {
+      return Promise.resolve(null);
+    }
     let promise;
     loadingTabs.add(tabId);
     if (hasSeenOnboarding) {


### PR DESCRIPTION
This patch consistently fixes #3097 for me. Two parts:

1. When loading selector code into a page, manually concatenate all scripts, then kick off 1 `browser.tabs.executeScript` request. The old approach kicked off N `executeScript` promises sequentially, one for each script.

2. Double-check the list of already-loading tabs just before starting to load code into a tab. Although this check is done elsewhere already, adding a check at the moment of truth seems to fix the remaining few weird timing bugs that lead to 'haywire' notifications.