### PR TITLE
Fix #2140 "Remove Page Shot data" page is wrongly titled as "Confirm account deletion" 

### DIFF
--- a/locales/en-US/server.ftl
+++ b/locales/en-US/server.ftl
@@ -20,7 +20,7 @@ footerLinkMozilla = Mozilla
 footerLinkPrivacy = Privacy Notice
 footerLinkDMCA = Report IP Infringement
 footerLinkDiscourse = Give Feedback
-leavePageConfirmDelete = Remove All Data
+footerLinkRemoveAllData = Remove All Data
 
 [[ Creating page ]]
 
@@ -61,7 +61,7 @@ homePageCookiesLink = Cookies
 
 [[ Leave Screenshots page ]]
 
-leavePageRemoveAllData = Remove All Data
+leavePageConfirmDelete = Remove All Data
 // Note: do not translate 'Firefox Screenshots' when translating this string
 leavePageErrorAddonRequired = You must have Firefox Screenshots installed to delete your account
 leavePageErrorGeneric = An error occurred

--- a/locales/en-US/server.ftl
+++ b/locales/en-US/server.ftl
@@ -61,7 +61,7 @@ homePageCookiesLink = Cookies
 
 [[ Leave Screenshots page ]]
 
-leavePageConfirmDelete = Remove All Data
+leavePageRemoveAllData = Remove All Data
 // Note: do not translate 'Firefox Screenshots' when translating this string
 leavePageErrorAddonRequired = You must have Firefox Screenshots installed to delete your account
 leavePageErrorGeneric = An error occurred

--- a/locales/en-US/server.ftl
+++ b/locales/en-US/server.ftl
@@ -61,7 +61,7 @@ homePageCookiesLink = Cookies
 
 [[ Leave Screenshots page ]]
 
-leavePageConfirmDelete = Confirm account deletion
+leavePageConfirmDelete = Remove All Data
 // Note: do not translate 'Firefox Screenshots' when translating this string
 leavePageErrorAddonRequired = You must have Firefox Screenshots installed to delete your account
 leavePageErrorGeneric = An error occurred

--- a/locales/en-US/server.ftl
+++ b/locales/en-US/server.ftl
@@ -20,7 +20,7 @@ footerLinkMozilla = Mozilla
 footerLinkPrivacy = Privacy Notice
 footerLinkDMCA = Report IP Infringement
 footerLinkDiscourse = Give Feedback
-footerLinkRemoveAllData = Remove All Data
+leavePageConfirmDelete = Remove All Data
 
 [[ Creating page ]]
 

--- a/server/src/pages/leave-screenshots/model.js
+++ b/server/src/pages/leave-screenshots/model.js
@@ -1,7 +1,7 @@
 exports.createModel = function(req) {
   let complete = "complete" in req.query;
   return {
-    title: req.getText("leavePageConfirmDelete"),
+    title: req.getText("leavePageRemoveAllData"),
     complete
   };
 };

--- a/server/src/pages/leave-screenshots/model.js
+++ b/server/src/pages/leave-screenshots/model.js
@@ -1,7 +1,7 @@
 exports.createModel = function(req) {
   let complete = "complete" in req.query;
   return {
-    title: req.getText("leavePageConfirmDeletion"),
+    title: req.getText("leavePageConfirmDelete"),
     complete
   };
 };


### PR DESCRIPTION
The "Remove Page Shot data" page was wrongly titled as "Confirm account deletion" 
I changed it to "Remove All Data".