### PR TITLE
Load shot image directly

### DIFF
--- a/server/src/pages/shot/page.js
+++ b/server/src/pages/shot/page.js
@@ -2,19 +2,5 @@ const { Page } = require("../../reactruntime");
 
 exports.page = new Page({
   dir: __dirname,
-  viewModule: require("./view.js"),
-  extraBodyJavascript: `
-(function () {
-  var el = document.getElementById("clipImage");
-  if (el) {
-    el.addEventListener("load", function () {
-      el.style.display = 'inline';
-      var spinner = document.getElementById("spinner");
-      if (spinner) {
-        spinner.style.display = 'none';
-      }
-    }, false);
-  }
-})();
-`
+  viewModule: require("./view.js")
 });

--- a/server/src/pages/shot/view.js
+++ b/server/src/pages/shot/view.js
@@ -36,7 +36,7 @@ class Clip extends React.Component {
       return null;
     }
     let backgroundStyle = "transparent url('" + this.props.staticLink("/static/img/spinner.svg") + "') center no-repeat";
-    let node = <img id="clipImage" style={{height: "auto", width: clip.image.dimensions.x + "px", maxWidth: "100%", display: this.state.imageDisplay, background: backgroundStyle }} ref={clipImage => this.clipImage = clipImage} src={ clip.image.url } alt={ clip.image.text } />;
+    let node = <img id="clipImage" style={{height: "auto", width: clip.image.dimensions.x + "px", maxWidth: "100%", background: backgroundStyle }} ref={clipImage => this.clipImage = clipImage} src={ clip.image.url } alt={ clip.image.text } />;
     return <div ref={clipContainer => this.clipContainer = clipContainer} className="clip-container">
       { this.copyTextContextMenu() }
       <a href={ clip.image.url } onClick={ this.onClickClip.bind(this) } contextMenu="clip-image-context">

--- a/server/src/pages/shot/view.js
+++ b/server/src/pages/shot/view.js
@@ -10,17 +10,11 @@ const reactruntime = require("../../reactruntime");
 class Clip extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {
-      loading: true,
-      imageDisplay: "none"
-    };
   }
 
   componentDidMount() {
+    // TODO: how can we resize nicely if JS is disabled? maybe CSS?
     let image = this.clipImage;
-    if (image.complete) {
-      this.onImageLoaded();
-    }
     let onResize = () => {
       let windowHeight = window.innerHeight;
       let paddingTop = Math.floor((windowHeight - image.height - 35) / 2);
@@ -41,10 +35,7 @@ class Clip extends React.Component {
       console.warn("Somehow there's a shot without an image");
       return null;
     }
-    let node = <img id="clipImage" style={{height: "auto", width: clip.image.dimensions.x + "px", maxWidth: "100%", display: this.state.imageDisplay}} ref={clipImage => this.clipImage = clipImage} src={ clip.image.url } alt={ clip.image.text } onLoad = { this.onImageLoaded.bind(this) } />;
-    // Note that in server/src/pages/shot/page.js there is also JavaScript defined
-    // that displays the image onload, as a backup to make sure the image always
-    // gets displayed even if the bundle doesn't load
+    let node = <img id="clipImage" style={{height: "auto", width: clip.image.dimensions.x + "px", maxWidth: "100%", display: this.state.imageDisplay}} ref={clipImage => this.clipImage = clipImage} src={ clip.image.url } alt={ clip.image.text } />;
     return <div ref={clipContainer => this.clipContainer = clipContainer} className="clip-container">
       { this.copyTextContextMenu() }
       { this.renderLoader() }
@@ -52,13 +43,6 @@ class Clip extends React.Component {
         { node }
       </a>
     </div>;
-  }
-
-  onImageLoaded() {
-    this.setState({
-      loading: false,
-      imageDisplay: "inline"
-    });
   }
 
   renderLoader() {

--- a/server/src/pages/shot/view.js
+++ b/server/src/pages/shot/view.js
@@ -35,22 +35,14 @@ class Clip extends React.Component {
       console.warn("Somehow there's a shot without an image");
       return null;
     }
-    let node = <img id="clipImage" style={{height: "auto", width: clip.image.dimensions.x + "px", maxWidth: "100%", display: this.state.imageDisplay}} ref={clipImage => this.clipImage = clipImage} src={ clip.image.url } alt={ clip.image.text } />;
+    let backgroundStyle = "transparent url('" + this.props.staticLink("/static/img/spinner.svg") + "') center no-repeat";
+    let node = <img id="clipImage" style={{height: "auto", width: clip.image.dimensions.x + "px", maxWidth: "100%", display: this.state.imageDisplay, background: backgroundStyle }} ref={clipImage => this.clipImage = clipImage} src={ clip.image.url } alt={ clip.image.text } />;
     return <div ref={clipContainer => this.clipContainer = clipContainer} className="clip-container">
       { this.copyTextContextMenu() }
-      { this.renderLoader() }
       <a href={ clip.image.url } onClick={ this.onClickClip.bind(this) } contextMenu="clip-image-context">
         { node }
       </a>
     </div>;
-  }
-
-  renderLoader() {
-    return (
-      <div id="spinner" className="spinner">
-        <img src = {this.props.staticLink("/static/img/spinner.svg")} />
-      </div>
-    );
   }
 
   onClickClip() {


### PR DESCRIPTION
TL;DR: moves shot image to a plain old image tag, making the shot page functional in IE, Edge, and any browser with JS disabled.

The shot image wasn't loading in Edge or IE (#2935) because those browsers don't support the CSP nonce directive. (The very latest version of Edge, released this week with the Windows 10 Creators Update, does support CSP level 2.) I'm not sure why the regular image loading detection code failed, but the CSP error explains why the inline fallback code failed.

This seemed like a good opportunity to get rid of the code that hides the image until it's loaded. Simplifies the code and makes the pages accessible without JS.

I set the spinner as a centered background image of the image tag itself; it's weird-looking now, but once jgruen replaces the svg with a simple png, should look good.