### PR TITLE
Replace the WebExtension browser action with a Photon page action.

### DIFF
--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -11,14 +11,16 @@ const { interfaces: Ci, utils: Cu } = Components;
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "AddonManager",
                                   "resource://gre/modules/AddonManager.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "AppConstants",
+                                  "resource://gre/modules/AppConstants.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "Console",
                                   "resource://gre/modules/Console.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "CustomizableUI",
                                   "resource:///modules/CustomizableUI.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "LegacyExtensionsUtils",
                                   "resource://gre/modules/LegacyExtensionsUtils.jsm");
- XPCOMUtils.defineLazyModuleGetter(this, "PageActions",
-                                   "resource:///modules/PageActions.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "PageActions",
+                                  "resource:///modules/PageActions.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "Services",
                                   "resource://gre/modules/Services.jsm");
 
@@ -218,60 +220,33 @@ function handleMessage(msg, sender, sendReply) {
 
 let photonPageAction;
 
-// Sets up the Photon page action.  Ideally, in the future, WebExtension page
-// actions and Photon page actions would be one in the same, but they aren't
-// right now.
+// If the current Firefox version supports Photon (57 and later), this sets up
+// a Photon page action and removes the UI for the WebExtension browser action.
+// Does nothing otherwise.  Ideally, in the future, WebExtension page actions
+// and Photon page actions would be one in the same, but they aren't right now.
 function initPhotonPageAction(api) {
-  let id = "screenshots";
-  photonPageAction = PageActions.actionForID(id);
-  if (photonPageAction) {
-    // The page action has already been set up (which shouldn't happen, but
-    // check anyway).
+  if (!AppConstants.MOZ_PHOTON_THEME) {
+    // Photon not supported.  Use the WebExtension's browser action.
     return;
   }
 
+  let id = "screenshots";
+  let port = null;
+  let baseIconPath = addonResourceURI.spec + "webextension/";
+
   let {Management: {global: {tabTracker}}} = Cu.import("resource://gre/modules/Extension.jsm", {});
 
-  let port = null;
-  let title = "Take a Screenshot";
-  let baseIconPath = addonResourceURI.spec + "webextension/";
-  let iconURL = baseIconPath + "icons/icon-32-v2.svg";
-
-  // Get a port to the WebExtension side.
-  api.browser.runtime.onConnect.addListener((listenerPort) => {
-    if (listenerPort.name == "photonPageActionPort") {
-      port = listenerPort;
-
-      // The WebExtension side of the port sends over the action's localized
-      // title and possibly updated iconURL.
-      port.onMessage.addListener((message) => {
-        if (message.title) {
-          if (photonPageAction) {
-            photonPageAction.title = message.title;
-          } else {
-            title = message.title;
-          }
-        }
-        if (message.iconPath) {
-          iconURL = baseIconPath + message.iconPath;
-          if (photonPageAction) {
-            photonPageAction.iconURL = iconURL;
-          }
-        }
-      });
-    }
-  });
-
-  // Add the page action.
-  photonPageAction = PageActions.addAction(new PageActions.Action({
+  // Make the page action.
+  photonPageAction = PageActions.actionForID(id) || PageActions.addAction(new PageActions.Action({
     id,
-    title,
-    iconURL,
+    title: "Take a Screenshot",
+    iconURL: baseIconPath + "icons/icon-32-v2.svg",
     _insertBeforeActionID: null,
     onCommand(event, buttonNode) {
       if (port) {
         let browserWin = buttonNode.ownerDocument.defaultView;
         port.postMessage({
+          type: "click",
           tab: {
             url: browserWin.gBrowser.selectedBrowser.currentURI.spec,
             id: tabTracker.getId(browserWin.gBrowser.selectedTab),
@@ -280,4 +255,46 @@ function initPhotonPageAction(api) {
       }
     },
   }));
+
+  // Remove the navbar button of the WebExtension's browser action.
+  let cuiWidgetID = "screenshots_mozilla_org-browser-action";
+  CustomizableUI.addListener({
+    onWidgetAfterCreation(wid, aArea) {
+      if (wid == cuiWidgetID) {
+        CustomizableUI.destroyWidget(cuiWidgetID);
+        CustomizableUI.removeListener(this);
+      }
+    },
+  });
+
+  // Establish a port to the WebExtension side.
+  api.browser.runtime.onConnect.addListener((listenerPort) => {
+    if (listenerPort.name != "photonPageActionPort") {
+      return;
+    }
+    port = listenerPort;
+    port.onMessage.addListener((message) => {
+      switch (message.type) {
+      case "setProperties":
+        if (message.title) {
+          photonPageAction.title = message.title;
+        }
+        if (message.iconPath) {
+          photonPageAction.iconURL = baseIconPath + message.iconPath;
+        }
+        break;
+      default:
+        console.error("Unrecognized message:", message);
+        break;
+      }
+    });
+
+    // It's necessary to tell the WebExtension not to use its browser action,
+    // due to the CUI widget's removal.  Otherwise Firefox's WebExtension
+    // machinery throws exceptions.
+    port.postMessage({
+      type: "setUsePhotonPageAction",
+      value: true
+    });
+  });
 }

--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -244,7 +244,7 @@ function initPhotonPageAction(api) {
     _insertBeforeActionID: null,
     onCommand(event, buttonNode) {
       if (port) {
-        let browserWin = buttonNode.ownerDocument.defaultView;
+        let browserWin = buttonNode.ownerGlobal;
         port.postMessage({
           type: "click",
           tab: {

--- a/addon/webextension/background/main.js
+++ b/addon/webextension/background/main.js
@@ -1,4 +1,4 @@
-/* globals selectorLoader, analytics, communication, catcher, log, makeUuid, auth, senderror */
+/* globals selectorLoader, analytics, communication, catcher, log, makeUuid, auth, senderror, startBackground */
 
 "use strict";
 

--- a/addon/webextension/background/main.js
+++ b/addon/webextension/background/main.js
@@ -18,9 +18,16 @@ this.main = (function() {
     if (!hasSeenOnboarding) {
       setIconActive(false, null);
       // Note that the branded name 'Firefox Screenshots' is not localized:
-      startBackground.photonPageActionPort.postMessage({
-        title: "Firefox Screenshots"
-      });
+      if (!startBackground.usePhotonPageAction) {
+        browser.browserAction.setTitle({
+          title: "Firefox Screenshots"
+        });
+      } else {
+        startBackground.photonPageActionPort.postMessage({
+          type: "setProperties",
+          title: "Firefox Screenshots"
+        });
+      }
     }
   }).catch((error) => {
     log.error("Error getting hasSeenOnboarding:", error);
@@ -55,9 +62,21 @@ this.main = (function() {
     if ((!hasSeenOnboarding) && !active) {
       path = "icons/icon-starred-32-v2.svg";
     }
-    startBackground.photonPageActionPort.postMessage({
-      iconPath: path
-    });
+    if (!startBackground.usePhotonPageAction) {
+      browser.browserAction.setIcon({path, tabId}).catch((error) => {
+        // FIXME: use errorCode
+        if (error.message && /Invalid tab ID/.test(error.message)) {
+          // This is a normal exception that we can ignore
+        } else {
+          catcher.unhandled(error);
+        }
+      });
+    } else {
+      startBackground.photonPageActionPort.postMessage({
+        type: "setProperties",
+        iconPath: path
+      });
+    }
   }
 
   function toggleSelector(tab) {
@@ -92,7 +111,8 @@ this.main = (function() {
     return /^about:(?:newtab|blank|home)/i.test(url) || /^resource:\/\/activity-streams\//i.test(url);
   }
 
-  // This is called by startBackground.js in response to clicks on the Photon page action
+  // This is called by startBackground.js, directly in response to browser.browserAction.onClicked
+  // and clicks on the Photon page action
   exports.onClicked = catcher.watchFunction((tab) => {
     if (tab.incognito) {
       senderror.showError({
@@ -269,9 +289,16 @@ this.main = (function() {
     hasSeenOnboarding = true;
     catcher.watchPromise(browser.storage.local.set({hasSeenOnboarding}));
     setIconActive(false, null);
-    startBackground.photonPageActionPort.postMessage({
-      title: browser.i18n.getMessage("contextMenuLabel")
-    });
+    if (!startBackground.usePhotonPageAction) {
+      browser.browserAction.setTitle({
+        title: browser.i18n.getMessage("contextMenuLabel")
+      });
+    } else {
+      startBackground.photonPageActionPort.postMessage({
+        type: "setProperties",
+        title: browser.i18n.getMessage("contextMenuLabel")
+      });
+    }
   });
 
   communication.register("abortFrameset", () => {

--- a/addon/webextension/background/main.js
+++ b/addon/webextension/background/main.js
@@ -18,7 +18,7 @@ this.main = (function() {
     if (!hasSeenOnboarding) {
       setIconActive(false, null);
       // Note that the branded name 'Firefox Screenshots' is not localized:
-      browser.browserAction.setTitle({
+      startBackground.photonPageActionPort.postMessage({
         title: "Firefox Screenshots"
       });
     }
@@ -55,13 +55,8 @@ this.main = (function() {
     if ((!hasSeenOnboarding) && !active) {
       path = "icons/icon-starred-32-v2.svg";
     }
-    browser.browserAction.setIcon({path, tabId}).catch((error) => {
-      // FIXME: use errorCode
-      if (error.message && /Invalid tab ID/.test(error.message)) {
-        // This is a normal exception that we can ignore
-      } else {
-        catcher.unhandled(error);
-      }
+    startBackground.photonPageActionPort.postMessage({
+      iconPath: path
     });
   }
 
@@ -97,7 +92,7 @@ this.main = (function() {
     return /^about:(?:newtab|blank|home)/i.test(url) || /^resource:\/\/activity-streams\//i.test(url);
   }
 
-  // This is called by startBackground.js, directly in response to browser.browserAction.onClicked
+  // This is called by startBackground.js in response to clicks on the Photon page action
   exports.onClicked = catcher.watchFunction((tab) => {
     if (tab.incognito) {
       senderror.showError({
@@ -274,7 +269,7 @@ this.main = (function() {
     hasSeenOnboarding = true;
     catcher.watchPromise(browser.storage.local.set({hasSeenOnboarding}));
     setIconActive(false, null);
-    browser.browserAction.setTitle({
+    startBackground.photonPageActionPort.postMessage({
       title: browser.i18n.getMessage("contextMenuLabel")
     });
   });

--- a/addon/webextension/manifest.json.template
+++ b/addon/webextension/manifest.json.template
@@ -11,14 +11,6 @@
     }
   },
   "default_locale": "en_US",
-  "browser_action": {
-    "default_icon": {
-      "16": "icons/icon-16-v2.svg",
-      "32": "icons/icon-32-v2.svg"
-    },
-    "default_title": "Firefox Screenshots",
-    "browser_style": false
-  },
   "background": {
     "scripts": [
       "build/buildSettings.js",

--- a/addon/webextension/manifest.json.template
+++ b/addon/webextension/manifest.json.template
@@ -11,6 +11,14 @@
     }
   },
   "default_locale": "en_US",
+  "browser_action": {
+    "default_icon": {
+      "16": "icons/icon-16-v2.svg",
+      "32": "icons/icon-32-v2.svg"
+    },
+    "default_title": "Firefox Screenshots",
+    "browser_style": false
+  },
   "background": {
     "scripts": [
       "build/buildSettings.js",

--- a/test/addon/browser_screenshots_ui_check.js
+++ b/test/addon/browser_screenshots_ui_check.js
@@ -13,9 +13,12 @@ add_task(async function() {
     await promiseScreenshotsReset();
   });
 
+  let id = AppConstants.MOZ_PHOTON_THEME ? "pageAction-panel-screenshots"
+                                         : "screenshots_mozilla_org-browser-action";
+
   await BrowserTestUtils.waitForCondition(
-    () => document.getElementById("pageAction-panel-screenshots"),
+    () => document.getElementById(id),
     "Screenshots button should be present", 100, 100);
 
-  checkElements(true, ["pageAction-panel-screenshots"]);
+  checkElements(true, [id]);
 });

--- a/test/addon/browser_screenshots_ui_check.js
+++ b/test/addon/browser_screenshots_ui_check.js
@@ -14,8 +14,8 @@ add_task(async function() {
   });
 
   await BrowserTestUtils.waitForCondition(
-    () => document.getElementById("screenshots_mozilla_org-browser-action"),
+    () => document.getElementById("pageAction-panel-screenshots"),
     "Screenshots button should be present", 100, 100);
 
-  checkElements(true, ["screenshots_mozilla_org-browser-action"]);
+  checkElements(true, ["pageAction-panel-screenshots"]);
 });

--- a/test/addon/head.js
+++ b/test/addon/head.js
@@ -13,14 +13,27 @@ function promiseScreenshotsEnabled() {
   }
   info("Screenshots is not enabled");
   return new Promise((resolve, reject) => {
-    let interval = setInterval(() => {
-      let action = PageActions.actionForID("screenshots");
-      if (action) {
-        info("screenshots page action created");
-        clearInterval(interval);
-        resolve(false);
+    if (!AppConstants.MOZ_PHOTON_THEME) {
+      let listener = {
+        onWidgetAfterCreation(widgetid) {
+          if (widgetid == "screenshots_mozilla_org-browser-action") {
+            info("screenshots_mozilla_org-browser-action button created");
+            CustomizableUI.removeListener(listener);
+            resolve(false);
+          }
+        }
       }
-    }, 100);
+      CustomizableUI.addListener(listener);
+    } else {
+      let interval = setInterval(() => {
+        let action = PageActions.actionForID("screenshots");
+        if (action) {
+          info("screenshots page action created");
+          clearInterval(interval);
+          resolve(false);
+        }
+      }, 100);
+    }
     info("Set Screenshots disabled pref to false.");
     Services.prefs.setBoolPref("extensions.screenshots.system-disabled", false);
   });
@@ -32,14 +45,27 @@ function promiseScreenshotsDisabled() {
     return Promise.resolve(true);
   }
   return new Promise((resolve, reject) => {
-    let interval = setInterval(() => {
-      let action = PageActions.actionForID("screenshots");
-      if (!action) {
-        info("screenshots page action removed");
-        clearInterval(interval);
-        resolve(false);
+    if (!AppConstants.MOZ_PHOTON_THEME) {
+      let listener = {
+        onWidgetDestroyed(widgetid) {
+          if (widgetid == "screenshots_mozilla_org-browser-action") {
+            CustomizableUI.removeListener(listener);
+            info("screenshots_mozilla_org-browser-action destroyed");
+            resolve(false);
+          }
+        }
       }
-    }, 100);
+      CustomizableUI.addListener(listener);
+    } else {
+      let interval = setInterval(() => {
+        let action = PageActions.actionForID("screenshots");
+        if (!action) {
+          info("screenshots page action removed");
+          clearInterval(interval);
+          resolve(false);
+        }
+      }, 100);
+    }
     info("Set Screenshots disabled pref to true.");
     Services.prefs.setBoolPref("extensions.screenshots.system-disabled", true);
   });

--- a/test/addon/head.js
+++ b/test/addon/head.js
@@ -1,3 +1,5 @@
+/* globals PageActions */
+
 // Currently Screenshots is disabled in tests.  We want these tests to work under
 // either case that Screenshots is disabled or enabled on startup of the browser,
 // and that at the end we're reset to the correct state.

--- a/test/addon/head.js
+++ b/test/addon/head.js
@@ -13,16 +13,14 @@ function promiseScreenshotsEnabled() {
   }
   info("Screenshots is not enabled");
   return new Promise((resolve, reject) => {
-    let listener = {
-      onWidgetAfterCreation(widgetid) {
-        if (widgetid == "screenshots_mozilla_org-browser-action") {
-          info("screenshots_mozilla_org-browser-action button created");
-          CustomizableUI.removeListener(listener);
-          resolve(false);
-        }
+    let interval = setInterval(() => {
+      let action = PageActions.actionForID("screenshots");
+      if (action) {
+        info("screenshots page action created");
+        clearInterval(interval);
+        resolve(false);
       }
-    }
-    CustomizableUI.addListener(listener);
+    }, 100);
     info("Set Screenshots disabled pref to false.");
     Services.prefs.setBoolPref("extensions.screenshots.system-disabled", false);
   });
@@ -34,16 +32,14 @@ function promiseScreenshotsDisabled() {
     return Promise.resolve(true);
   }
   return new Promise((resolve, reject) => {
-    let listener = {
-      onWidgetDestroyed(widgetid) {
-        if (widgetid == "screenshots_mozilla_org-browser-action") {
-          CustomizableUI.removeListener(listener);
-          info("screenshots_mozilla_org-browser-action destroyed");
-          resolve(false);
-        }
+    let interval = setInterval(() => {
+      let action = PageActions.actionForID("screenshots");
+      if (!action) {
+        info("screenshots page action removed");
+        clearInterval(interval);
+        resolve(false);
       }
-    }
-    CustomizableUI.addListener(listener);
+    }, 100);
     info("Set Screenshots disabled pref to true.");
     Services.prefs.setBoolPref("extensions.screenshots.system-disabled", true);
   });

--- a/test/test.js
+++ b/test/test.js
@@ -16,7 +16,7 @@ const webdriver = require("selenium-webdriver");
 const { By, until } = webdriver;
 const path = require("path");
 
-const SHOOTER_BUTTON_ID = "screenshots_mozilla_org-browser-action";
+const SHOOTER_BUTTON_ID = "pageAction-panel-screenshots";
 const SLIDE_IFRAME_ID = "firefox-screenshots-onboarding-iframe";
 const PRESELECTION_IFRAME_ID = "firefox-screenshots-preselection-iframe";
 const PREVIEW_IFRAME_ID = "firefox-screenshots-preview-iframe";

--- a/test/test.js
+++ b/test/test.js
@@ -222,7 +222,7 @@ describe("Test Screenshots", function() {
       getChromeElement(driver, By.id(SHOOTER_BUTTON_ID))
       .then((button) => button.getAttribute("label"))
       .then((label) => {
-        assert.equal(label, "Firefox Screenshots");
+        assert.equal(label, "Take a Screenshot");
       }),
       () => {
         driver.setContext(firefox.Context.CONTENT);


### PR DESCRIPTION
This removes the browser action and adds a Photon page action,
pursuant to https://bugzilla.mozilla.org/show_bug.cgi?id=1366041.
Right now Photon page actions are unrelated to WebExtension page
actions unfortunately, which means that this patch has to do most
of its work in bootstrap.js.  The WebExtension part passes
messages to bootstrap.js to handle clicks and update the action's
title and icon as necessary.