### PR TITLE
remove extra space under firefox promo bar

### DIFF
--- a/server/src/pages/shot/view.js
+++ b/server/src/pages/shot/view.js
@@ -387,8 +387,8 @@ class Body extends React.Component {
 
     return (
       <reactruntime.BodyTemplate {...this.props}>
+        { renderGetFirefox ? this.renderFirefoxRequired() : null }
         <div id="frame" className="inverse-color-scheme full-height column-space">
-          { renderGetFirefox ? this.renderFirefoxRequired() : null }
         <div className="frame-header default-color-scheme">
         <a className="block-button button secondary" href={ myShotsHref } onClick={this.onClickMyShots.bind(this)}>{ myShotsText }</a>
           <div className="shot-main-actions">


### PR DESCRIPTION
Fixes #3201 
Looks like the issue was with the column-space class. Moving the promo bar out of the flow seems to have fixed the problem (tested on chrome and safari).