### PR TITLE
Fix #3271, insert a space between sentences in Get Firefox CTA

### DIFF
--- a/server/src/pages/shot/view.js
+++ b/server/src/pages/shot/view.js
@@ -427,6 +427,7 @@ class Body extends React.Component {
         <Localized id="gScreenshotsDescription">
           <span>Screenshots made simple. Take, save and share screenshots without leaving Firefox.</span>
         </Localized>
+        &nbsp;
         <Localized id="shotPageUpsellFirefox">
           <a href="https://www.mozilla.org/firefox/new/?utm_source=screenshots.firefox.com&utm_medium=referral&utm_campaign=screenshots-acquisition" onClick={ this.clickedInstallFirefox.bind(this) }>Get Firefox now</a>
         </Localized>


### PR DESCRIPTION

before:
<img width="249" alt="screen shot 2017-08-04 at 8 49 58 am" src="https://user-images.githubusercontent.com/96396/28976387-82506a6e-78f2-11e7-918f-7da59ef67b51.png">

after:
<img width="320" alt="screen shot 2017-08-04 at 8 51 59 am" src="https://user-images.githubusercontent.com/96396/28976378-7e3614a6-78f2-11e7-8c30-9b468251a1c5.png">
