### PR TITLE
Detach app startup observer on shutdown

### DIFF
--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -135,6 +135,7 @@ function startup(data, reason) { // eslint-disable-line no-unused-vars
 
 function shutdown(data, reason) { // eslint-disable-line no-unused-vars
   prefObserver.unregister();
+  appStartupObserver.unregister();
   const webExtension = LegacyExtensionsUtils.getEmbeddedExtensionFor({
     id: ADDON_ID,
     resourceURI: addonResourceURI


### PR DESCRIPTION
One of the Talos tests prevents this event from firing, leading to
intermittent crashes on Windows (https://bugzil.la/1387598).

Fixes #3301.