### PR TITLE
Correctly position share panel on non-Firefox browsers

### DIFF
--- a/static/css/partials/_share-panel.scss
+++ b/static/css/partials/_share-panel.scss
@@ -18,7 +18,7 @@
   width: 350px;
   z-index: 999;
 
-  .alt-notification + .frame-header & {
+  .alt-notification + #frame & {
     @include respond-to("medium") {
       top: 150px;
     }


### PR DESCRIPTION
Fixes #2873.

@johngruen R? Kinda brittle selector, but works