### PR TITLE
Simplify retrieval of My Shots data, hopefully speeding things up

### DIFF
--- a/server/src/pages/shotindex/server.js
+++ b/server/src/pages/shotindex/server.js
@@ -16,7 +16,7 @@ app.get("/", csrf({cookie: true}), function(req, res) {
   let query = req.query.q || null;
   let getShots = Promise.resolve(null);
   if (req.deviceId && req.query.withdata) {
-    getShots = Shot.getShotsForDevice(req.backend, req.deviceId, query);
+    getShots = Shot.getShotsForDevice(req.backend, req.deviceId, req.accountId, query);
   }
   getShots.then(_render)
     .catch((err) => {

--- a/server/src/servershot.js
+++ b/server/src/servershot.js
@@ -459,18 +459,17 @@ Shot.checkOwnership = function(shotId, deviceId, accountId) {
   })
 };
 
-Shot.getShotsForDevice = function(backend, deviceId, searchQuery) {
+Shot.getShotsForDevice = function(backend, deviceId, accountId, searchQuery) {
   if (!deviceId) {
     throw new Error("Empty deviceId: " + deviceId);
   }
+  // accountId is null if not set, treated as NULL in the SQL query
   return db.select(
     `SELECT DISTINCT devices.id
-     FROM devices, devices AS devices2
-     WHERE devices.id = $1
-           OR (devices.accountid = devices2.accountid
-               AND devices2.id = $1)
+     FROM devices
+     WHERE devices.id = $1 OR devices.accountid = $2
     `,
-    [deviceId]
+    [deviceId, accountId]
   ).then((rows) => {
     searchQuery = searchQuery || null;
     let ids = [];


### PR DESCRIPTION
Looking at the DB queries that generate the My Shots page, the query that [gets all devices for the current user](https://github.com/mozilla-services/screenshots/blob/6608d2e3f229c5fb986ddba557dab1bfe1711bca/server/src/servershot.js#L467-L471) seems problematic, based on the EXPLAIN output (note the Seq Scan):

```
jhirsch=# EXPLAIN ANALYZE SELECT DISTINCT devices.id FROM devices, devices AS devices2 WHERE devices.id = 'anoneb12496a-e845-4f09-8fa6-0e877b7d4438' OR (devices.accountid = devices2.accountid AND devices2.id = 'anoneb12496a-e845-4f09-8fa6-0e877b7d4438');
 Unique  (cost=22395.73..22407.76 rows=2405 width=33) (actual time=40.324..40.768 rows=1 loops=1)
   ->  Sort  (cost=22395.73..22401.75 rows=2405 width=33) (actual time=40.324..40.511 rows=2420 loops=1)
         Sort Key: devices.id
         Sort Method: quicksort  Memory: 286kB
         ->  Nested Loop  (cost=5.19..22260.67 rows=2405 width=33) (actual time=0.039..39.835 rows=2420 loops=1)
               ->  Seq Scan on devices devices2  (cost=0.00..81.05 rows=2405 width=451) (actual time=0.006..1.167 rows=2420 loops=1)
               ->  Bitmap Heap Scan on devices  (cost=5.19..9.21 rows=1 width=451) (actual time=0.015..0.015 rows=1 loops=2420)
                     Recheck Cond: (((id)::text = 'anoneb12496a-e845-4f09-8fa6-0e877b7d4438'::text) OR ((accountid)::text = (devices2.accountid)::text))
                     Filter: (((id)::text = 'anoneb12496a-e845-4f09-8fa6-0e877b7d4438'::text) OR (((accountid)::text = (devices2.accountid)::text) AND ((devices2.id)::text = 'anoneb12496a-e845-4f09-8fa6-0e877b7d4438'::text)))
                     Heap Blocks: exact=2420
                     ->  BitmapOr  (cost=5.19..5.19 rows=1 width=0) (actual time=0.014..0.014 rows=0 loops=2420)
                           ->  Bitmap Index Scan on devices_pkey  (cost=0.00..4.29 rows=1 width=0) (actual time=0.014..0.014 rows=1 loops=2420)
                                 Index Cond: ((id)::text = 'anoneb12496a-e845-4f09-8fa6-0e877b7d4438'::text)
                           ->  Bitmap Index Scan on devices_accountid_idx  (cost=0.00..0.31 rows=1 width=0) (actual time=0.000..0.000 rows=0 loops=2420)
                                 Index Cond: ((accountid)::text = (devices2.accountid)::text)
 Planning time: 0.162 ms
 Execution time: 40.799 ms
```

Ian pointed out that we already have the accountId, if it exists. Modifying the query to take advantage of accountId dramatically reduces the `cost` of the query from around 20000 to around 10:

```
jhirsch=# EXPLAIN ANALYZE SELECT DISTINCT devices.id FROM devices WHERE devices.id = 'anoneb12496a-e845-4f09-8fa6-0e877b7d4438' OR devices.accountid = 'd4f047ab839511e79498784f4376aa68';
 Unique  (cost=12.60..12.61 rows=1 width=33) (actual time=0.077..0.078 rows=1 loops=1)
   ->  Sort  (cost=12.60..12.61 rows=1 width=33) (actual time=0.077..0.078 rows=1 loops=1)
         Sort Key: id
         Sort Method: quicksort  Memory: 25kB
         ->  Bitmap Heap Scan on devices  (cost=8.58..12.59 rows=1 width=33) (actual time=0.069..0.070 rows=1 loops=1)
               Recheck Cond: (((id)::text = 'anoneb12496a-e845-4f09-8fa6-0e877b7d4438'::text) OR ((accountid)::text = 'd4f047ab839511e79498784f4376aa68'::text))
               Heap Blocks: exact=1
               ->  BitmapOr  (cost=8.58..8.58 rows=1 width=0) (actual time=0.028..0.028 rows=0 loops=1)
                     ->  Bitmap Index Scan on devices_pkey  (cost=0.00..4.29 rows=1 width=0) (actual time=0.023..0.023 rows=1 loops=1)
                           Index Cond: ((id)::text = 'anoneb12496a-e845-4f09-8fa6-0e877b7d4438'::text)
                     ->  Bitmap Index Scan on devices_accountid_idx  (cost=0.00..4.29 rows=1 width=0) (actual time=0.003..0.003 rows=0 loops=1)
                           Index Cond: ((accountid)::text = 'd4f047ab839511e79498784f4376aa68'::text)
 Planning time: 10.119 ms
 Execution time: 0.105 ms
```

I've been advocating taking a less piecemeal approach to optimization, but eliminating a full table scan seems like a clear win.