### PR TITLE
Server test responses

### DIFF
--- a/server/src/pages/shotindex/model.js
+++ b/server/src/pages/shotindex/model.js
@@ -28,7 +28,7 @@ exports.createModel = function(req) {
       image.url = createProxyUrl(req, image.url);
     }
   }
-  if (shots !== null) {
+  if (shots !== null && shots !== undefined) {
     shots = shots.map((shot) => ({id: shot.id, json: shot.asRecallJson()}));
   }
   let jsonModel = Object.assign(

--- a/server/src/pages/shotindex/view.js
+++ b/server/src/pages/shotindex/view.js
@@ -52,8 +52,10 @@ class Body extends React.Component {
       return this.renderShotsLoading();
     }
     let children = [];
-    for (let shot of this.props.shots) {
-      children.push(<Card shot={shot} downloadUrl={this.props.downloadUrls[shot.id]} abTests={this.props.abTests} clipUrl={shot.urlDisplay} isOwner={this.props.isOwner} staticLink={this.props.staticLink} isExtInstalled={this.props.isExtInstalled} key={shot.id} />);
+    if (this.props.shots && this.props.shots.length) {
+      for (let shot of this.props.shots) {
+        children.push(<Card shot={shot} downloadUrl={this.props.downloadUrls[shot.id]} abTests={this.props.abTests} clipUrl={shot.urlDisplay} isOwner={this.props.isOwner} staticLink={this.props.staticLink} isExtInstalled={this.props.isExtInstalled} key={shot.id} />);
+      }
     }
 
     if (children.length === 0) {

--- a/test/server/clientlib.py
+++ b/test/server/clientlib.py
@@ -1,5 +1,6 @@
 import os
 import re
+import contextlib
 import requests
 from urlparse import urljoin
 import json
@@ -107,6 +108,14 @@ class ScreenshotsClient(object):
         resp = self.session.get(urljoin(self.backend, "/shots"), params={"q": q})
         resp.raise_for_status()
 
+    def get_settings(self):
+        resp = self.session.get(urljoin(self.backend, "/settings/"))
+        resp.raise_for_status()
+        return resp
+
+    def get_uri(self, uri):
+        return self.session.get(urljoin(self.backend, uri))
+
 
 def make_example_shot(deviceId, pad_image_to_length=None, image_index=None, **overrides):
     if image_index is None:
@@ -171,3 +180,14 @@ def make_uuid():
 
 def make_random_id():
     return make_uuid()[:16]
+
+
+@contextlib.contextmanager
+def screenshots_session(backend=None):
+    if backend:
+        user = ScreenshotsClient(backend=backend)
+    else:
+        user = ScreenshotsClient()
+    user.login()
+    yield user
+    user.delete_account()

--- a/test/server/test_responses.py
+++ b/test/server/test_responses.py
@@ -130,4 +130,8 @@ if __name__ == "__main__":
     test_landing_page()
     test_creating_page()
     test_404_page()
+    test_contribute_json()
+    test_dunder_version()
+    test_heartbeat()
+    test_lbheartbeat()
     test_my_shots_page()

--- a/test/server/test_responses.py
+++ b/test/server/test_responses.py
@@ -110,10 +110,7 @@ def test_lbheartbeat():
 
 def test_my_shots_page():
     with screenshots_session() as user:
-        shot_url = user.create_shot(docTitle="A_TEST_SITE_1", image_index=0)
-        shot_id = urlparse.urlsplit(shot_url).path.strip("/")
-
-        shot_page = user.read_my_shots()
+        user.read_my_shots()
 
     # e.g. direct navigation to /shots in private window
     unauthed_user = ScreenshotsClient()

--- a/test/server/test_responses.py
+++ b/test/server/test_responses.py
@@ -115,10 +115,10 @@ def test_my_shots_page():
 
         shot_page = user.read_my_shots()
 
+    # e.g. direct navigation to /shots in private window
     unauthed_user = ScreenshotsClient()
     response = unauthed_user.get_uri("/shots")
-    if response.status_code != 500:  # TODO: fix direct navigation to /shots in private window
-        response.raise_for_status()
+    response.raise_for_status()
 
 
 if __name__ == "__main__":

--- a/test/server/test_responses.py
+++ b/test/server/test_responses.py
@@ -1,6 +1,10 @@
-from clientlib import ScreenshotsClient
+from clientlib import ScreenshotsClient, screenshots_session
+import urlparse
+from urlparse import urljoin
 import random
+import requests
 from requests import HTTPError
+
 
 # Hack to make this predictable:
 random.seed(0)
@@ -32,6 +36,98 @@ def test_bad_id():
         user.delete_account()
 
 
+def test_settings_page():
+    with screenshots_session() as user:
+        user.get_settings()  # raises for http error
+
+
+def test_settings_page_requires_auth():
+    user = ScreenshotsClient()
+
+    resp = requests.get(urljoin(user.backend, "/settings"))
+    assert resp.status_code == 403
+
+
+def test_metrics_page():
+    unauthed_user = ScreenshotsClient()
+
+    resp = requests.get(urljoin(unauthed_user.backend, "/metrics"))
+    assert resp.status_code == 200
+
+
+def test_landing_page():
+    unauthed_user = ScreenshotsClient()
+
+    resp = unauthed_user.get_uri("/")
+    assert resp.status_code == 200
+
+
+def test_creating_page():
+    with screenshots_session() as user:
+        shot_url = user.create_shot(docTitle="A_TEST_SITE_1", image_index=0)
+        shot_id = urlparse.urlsplit(shot_url).path.strip("/")
+
+        resp = user.get_uri("/creating/" + shot_id)
+        assert resp.status_code == 200
+
+    unauthed_user = ScreenshotsClient()
+
+    resp = requests.get(urljoin(unauthed_user.backend, "/creating/") + shot_id)
+    assert resp.status_code == 200
+
+
+def test_404_page():
+    unauthed_user = ScreenshotsClient()
+    response = unauthed_user.get_uri("/404")
+    if response.status_code != 404:
+        response.raise_for_status()
+
+
+def test_contribute_json():
+    unauthed_user = ScreenshotsClient()
+    response = unauthed_user.get_uri("/contribute.json")
+    if response.status_code != 200:
+        response.raise_for_status()
+
+
+def test_dunder_version():
+    unauthed_user = ScreenshotsClient()
+    response = unauthed_user.get_uri("/__version__")
+    response.raise_for_status()
+
+
+def test_heartbeat():
+    unauthed_user = ScreenshotsClient()
+    response = unauthed_user.get_uri("/__heartbeat__")
+    response.raise_for_status()
+
+
+def test_lbheartbeat():
+    unauthed_user = ScreenshotsClient()
+    response = unauthed_user.get_uri("/__lbheartbeat__")
+    response.raise_for_status()
+
+
+def test_my_shots_page():
+    with screenshots_session() as user:
+        shot_url = user.create_shot(docTitle="A_TEST_SITE_1", image_index=0)
+        shot_id = urlparse.urlsplit(shot_url).path.strip("/")
+
+        shot_page = user.read_my_shots()
+
+    unauthed_user = ScreenshotsClient()
+    response = unauthed_user.get_uri("/shots")
+    if response.status_code != 500:  # TODO: fix direct navigation to /shots in private window
+        response.raise_for_status()
+
+
 if __name__ == "__main__":
     test_put_large_image()
     test_bad_id()
+    test_settings_page()
+    test_settings_page_requires_auth()
+    test_metrics_page()
+    test_landing_page()
+    test_creating_page()
+    test_404_page()
+    test_my_shots_page()


### PR DESCRIPTION
Adds smoke tests for more routes and fixes a 500 error loading my shots from an unauthed page with no shots.

I can rebase this if the changes in clientlib might conflict with #3417

r? @ianb 