### PR TITLE
3299 header tweaks take 2

### DIFF
--- a/server/src/middleware/csrf.js
+++ b/server/src/middleware/csrf.js
@@ -19,7 +19,7 @@ exports.csrf = function(req, res, next) {
     let exc = new Error("Duplicate CSRF cookies");
     exc.headerValue = rawCookies;
     captureRavenException(exc);
-    simpleResponse(res, "Bad request", 400);
+    return simpleResponse(res, "Bad request", 400);
   }
   req.cookies._csrf = req.cookies.get("_csrf"); // csurf expects a property
   next();

--- a/server/src/middleware/csrf.js
+++ b/server/src/middleware/csrf.js
@@ -3,20 +3,24 @@ const mozlog = require("../logging").mozlog("csrf-middleware");
 const { captureRavenException } = require("../ravenclient");
 const { simpleResponse } = require("../responses");
 
-exports.csrfProtection = csrf({cookie: {httpOnly: true, secure: true, sameSite: 'lax', key: '__Host-csrf'}});
+const config = require("../config").getProperties();
+
+const useSecureCsrfCookie = (config.expectProtocol && /^https$/.test(config.expectProtocol));
+
+exports.csrfProtection = csrf({cookie: {httpOnly: true, secure: useSecureCsrfCookie}});
 
 exports.csrf = function(req, res, next) {
   // The cookies library doesn't detect duplicates; check manually
   let rawCookies = req.get("cookie") || "";
   let pairs = rawCookies.split(";");
-  let csrfTokens = pairs.filter(item => item.match(/__Host-csrf=/));
+  let csrfTokens = pairs.filter(item => item.match(/_csrf=/));
   if (csrfTokens.length > 1) {
     let exc = new Error("Duplicate CSRF cookies");
     exc.headerValue = rawCookies;
     captureRavenException(exc);
     simpleResponse(res, "Bad request", 400);
   }
-  req.cookies._csrf = req.cookies.get("__Host-csrf"); // csurf expects a property
+  req.cookies._csrf = req.cookies.get("_csrf"); // csurf expects a property
   next();
 };
 

--- a/server/src/middleware/csrf.js
+++ b/server/src/middleware/csrf.js
@@ -1,0 +1,31 @@
+const csrf = require("csurf");
+const mozlog = require("../logging").mozlog("csrf-middleware");
+const { captureRavenException } = require("../ravenclient");
+const { simpleResponse } = require("../responses");
+
+exports.csrfProtection = csrf({cookie: {httpOnly: true, secure: true, sameSite: 'lax', key: '__Host-csrf'}});
+
+exports.csrf = function(req, res, next) {
+  // The cookies library doesn't detect duplicates; check manually
+  let rawCookies = req.get("cookie") || "";
+  let pairs = rawCookies.split(";");
+  let csrfTokens = pairs.filter(item => item.match(/__Host-csrf=/));
+  if (csrfTokens.length > 1) {
+    let exc = new Error("Duplicate CSRF cookies");
+    exc.headerValue = rawCookies;
+    captureRavenException(exc);
+    simpleResponse(res, "Bad request", 400);
+  }
+  req.cookies._csrf = req.cookies.get("__Host-csrf"); // csurf expects a property
+  next();
+};
+
+exports.csrfErrorHandler = function(err, req, res, next) {
+  if (err.code !== "EBADCSRFTOKEN") {
+    next();
+  }
+  mozlog.info("bad-csrf", {id: req.ip, url: req.url});
+  res.status(403);
+  res.type("text");
+  res.send("Bad CSRF Token")
+};

--- a/server/src/middleware/csrf.js
+++ b/server/src/middleware/csrf.js
@@ -1,3 +1,4 @@
+const assert = require("assert");
 const csrf = require("csurf");
 const mozlog = require("../logging").mozlog("csrf-middleware");
 const { captureRavenException } = require("../ravenclient");
@@ -24,12 +25,10 @@ exports.csrf = function(req, res, next) {
   next();
 };
 
-exports.csrfErrorHandler = function(err, req, res, next) {
-  if (err.code !== "EBADCSRFTOKEN") {
-    next();
-  }
+exports.csrfErrorResponse = function(err, req, res) {
+  assert(err.code === "EBADCSRFTOKEN", "Returning csrf response for non-csrf error code.");
   mozlog.info("bad-csrf", {id: req.ip, url: req.url});
   res.status(403);
   res.type("text");
-  res.send("Bad CSRF Token")
+  res.send("Bad CSRF Token");
 };

--- a/server/src/pages/leave-screenshots/server.js
+++ b/server/src/pages/leave-screenshots/server.js
@@ -4,7 +4,7 @@ const reactrender = require("../../reactrender");
 const { Shot } = require("../../servershot");
 const mozlog = require("../../logging").mozlog("leave-screenshots");
 
-const csrfProtection = csrf({cookie: true});
+const csrfProtection = csrf({cookie: {httpOnly: true, secure: true, sameSite: 'lax', key: '__Host-csrf'}});
 let app = express();
 
 exports.app = app;

--- a/server/src/pages/leave-screenshots/server.js
+++ b/server/src/pages/leave-screenshots/server.js
@@ -1,10 +1,9 @@
 const express = require("express");
-const csrf = require('csurf');
 const reactrender = require("../../reactrender");
 const { Shot } = require("../../servershot");
 const mozlog = require("../../logging").mozlog("leave-screenshots");
+const { csrfProtection } = require("../../middleware/csrf");
 
-const csrfProtection = csrf({cookie: {httpOnly: true, secure: true, sameSite: 'lax', key: '__Host-csrf'}});
 let app = express();
 
 exports.app = app;

--- a/server/src/pages/settings/server.js
+++ b/server/src/pages/settings/server.js
@@ -1,12 +1,13 @@
 const express = require("express");
 const csrf = require("csurf");
+const csrfProtection = csrf({cookie: {httpOnly: true, secure: true, sameSite: 'lax', key: '__Host-csrf'}});
 const reactrender = require("../../reactrender");
 
 let app = express();
 
 exports.app = app;
 
-app.get("/", csrf({cookie: true}), function(req, res) {
+app.get("/", csrfProtection, function(req, res) {
   if (!req.deviceId) {
     res.status(403).send("You must have Screenshots installed");
     return;

--- a/server/src/pages/settings/server.js
+++ b/server/src/pages/settings/server.js
@@ -1,6 +1,5 @@
 const express = require("express");
-const csrf = require("csurf");
-const csrfProtection = csrf({cookie: {httpOnly: true, secure: true, sameSite: 'lax', key: '__Host-csrf'}});
+const { csrfProtection } = require("../../middleware/csrf");
 const reactrender = require("../../reactrender");
 
 let app = express();

--- a/server/src/pages/shot/server.js
+++ b/server/src/pages/shot/server.js
@@ -1,5 +1,6 @@
 const express = require("express");
 const csrf = require("csurf");
+const csrfProtection = csrf({cookie: {httpOnly: true, secure: true, sameSite: 'lax', key: '__Host-csrf'}});
 const { Shot } = require("../../servershot");
 const { notFound } = require("../../pages/not-found/server");
 const reactrender = require("../../reactrender");
@@ -9,7 +10,7 @@ let app = express();
 
 exports.app = app;
 
-app.get("/:id/:domain", csrf({cookie: true}), function(req, res) {
+app.get("/:id/:domain", csrfProtection, function(req, res) {
   let shotId = `${req.params.id}/${req.params.domain}`;
   Shot.get(req.backend, shotId).then((shot) => {
     let noSuchShot = !shot;

--- a/server/src/pages/shot/server.js
+++ b/server/src/pages/shot/server.js
@@ -1,6 +1,5 @@
 const express = require("express");
-const csrf = require("csurf");
-const csrfProtection = csrf({cookie: {httpOnly: true, secure: true, sameSite: 'lax', key: '__Host-csrf'}});
+const { csrfProtection } = require("../../middleware/csrf");
 const { Shot } = require("../../servershot");
 const { notFound } = require("../../pages/not-found/server");
 const reactrender = require("../../reactrender");

--- a/server/src/pages/shotindex/server.js
+++ b/server/src/pages/shotindex/server.js
@@ -1,5 +1,6 @@
 const express = require("express");
 const csrf = require("csurf");
+const csrfProtection = csrf({cookie: {httpOnly: true, secure: true, sameSite: 'lax', key: '__Host-csrf'}});
 const reactrender = require("../../reactrender");
 const { Shot } = require("../../servershot");
 const mozlog = require("../../logging").mozlog("shotindex");
@@ -8,7 +9,7 @@ let app = express();
 
 exports.app = app;
 
-app.get("/", csrf({cookie: true}), function(req, res) {
+app.get("/", csrfProtection, function(req, res) {
   if (!req.deviceId) {
     _render();
     return;

--- a/server/src/pages/shotindex/server.js
+++ b/server/src/pages/shotindex/server.js
@@ -1,6 +1,5 @@
 const express = require("express");
-const csrf = require("csurf");
-const csrfProtection = csrf({cookie: {httpOnly: true, secure: true, sameSite: 'lax', key: '__Host-csrf'}});
+const { csrfProtection } = require("../../middleware/csrf");
 const reactrender = require("../../reactrender");
 const { Shot } = require("../../servershot");
 const mozlog = require("../../logging").mozlog("shotindex");

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -30,7 +30,7 @@ const dbschema = require("./dbschema");
 const express = require("express");
 const bodyParser = require('body-parser');
 const contentDisposition = require("content-disposition");
-const { csrf, csrfProtection, csrfErrorHandler } = require("./middleware/csrf");
+const { csrf, csrfProtection, csrfErrorResponse } = require("./middleware/csrf");
 const morgan = require("morgan");
 const linker = require("./linker");
 const { randomBytes } = require("./helpers");
@@ -1064,8 +1064,6 @@ require("./jobs").start();
 
 addRavenErrorHandler(app);
 
-app.use(csrfErrorHandler);
-
 app.use(function(err, req, res, next) {
   if (err.isAppError) {
     let { statusCode, headers, payload } = err.output;
@@ -1085,6 +1083,10 @@ app.use(function(err, req, res, next) {
     res.status(err.statusCode);
     res.type("text");
     res.send(res.message);
+    return;
+  }
+  if (err.code === "EBADCSRFTOKEN") {
+    csrfErrorResponse(err, req, res);
     return;
   }
   errorResponse(res, "General error:", err);

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -30,7 +30,7 @@ const dbschema = require("./dbschema");
 const express = require("express");
 const bodyParser = require('body-parser');
 const contentDisposition = require("content-disposition");
-const csrf = require("csurf");
+const { csrf, csrfProtection, csrfErrorHandler } = require("./middleware/csrf");
 const morgan = require("morgan");
 const linker = require("./linker");
 const { randomBytes } = require("./helpers");
@@ -94,8 +94,6 @@ function initDatabase() {
 }
 
 initDatabase();
-
-const csrfProtection = csrf({cookie: {httpOnly: true, secure: true, sameSite: 'lax', key: '__Host-csrf'}});
 
 const app = express();
 
@@ -218,23 +216,16 @@ app.use(function(req, res, next) {
     req.accountId = authInfo.accountId;
   }
   req.cookies = cookies;
-  // The cookies library doesn't detect duplicates; check manually
-  let rawCookies = req.get("cookie") || "";
-  let pairs = rawCookies.split(";");
-  let csrfTokens = pairs.filter(item => { return item.match(/__Host-csrf=/); });
-  if (csrfTokens.length > 1) {
-    let exc = new Error("Duplicate CSRF cookies");
-    exc.headerValue = rawCookies;
-    captureRavenException(exc);
-    simpleResponse(res, "Bad request", 400);
-  }
-  req.cookies._csrf = cookies.get("__Host-csrf"); // csurf expects a property
   req.abTests = authInfo.abTests || {};
   const host = req.headers.host === config.contentOrigin ? config.contentOrigin : config.siteOrigin;
   req.backend = `${req.protocol}://${host}`;
   req.config = config;
   next();
 });
+
+// NOTE - the csrf middleware should come after the middleware that
+// assigns req.cookies.
+app.use(csrf);
 
 function decodeAuthHeader(header) {
   /** Decode a string header in the format {deviceId}:{deviceIdSig};abtests={b64thing}:{sig} */
@@ -1073,6 +1064,8 @@ require("./jobs").start();
 
 addRavenErrorHandler(app);
 
+app.use(csrfErrorHandler);
+
 app.use(function(err, req, res, next) {
   if (err.isAppError) {
     let { statusCode, headers, payload } = err.output;
@@ -1092,13 +1085,6 @@ app.use(function(err, req, res, next) {
     res.status(err.statusCode);
     res.type("text");
     res.send(res.message);
-    return;
-  }
-  if (err.code === "EBADCSRFTOKEN") {
-    mozlog.info("bad-csrf", {ip: req.ip, url: req.url});
-    res.status(403);
-    res.type("text");
-    res.send("Bad CSRF Token")
     return;
   }
   errorResponse(res, "General error:", err);

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -95,7 +95,7 @@ function initDatabase() {
 
 initDatabase();
 
-const csrfProtection = csrf({cookie: true});
+const csrfProtection = csrf({cookie: {httpOnly: true, secure: true, sameSite: 'lax', key: '__Host-csrf'}});
 
 const app = express();
 
@@ -218,7 +218,17 @@ app.use(function(req, res, next) {
     req.accountId = authInfo.accountId;
   }
   req.cookies = cookies;
-  req.cookies._csrf = cookies.get("_csrf"); // csurf expects a property
+  // The cookies library doesn't detect duplicates; check manually
+  let rawCookies = req.get("cookie") || "";
+  let pairs = rawCookies.split(";");
+  let csrfTokens = pairs.filter(item => { return item.match(/__Host-csrf=/); });
+  if (csrfTokens.length > 1) {
+    let exc = new Error("Duplicate CSRF cookies");
+    exc.headerValue = rawCookies;
+    captureRavenException(exc);
+    simpleResponse(res, "Bad request", 400);
+  }
+  req.cookies._csrf = cookies.get("__Host-csrf"); // csurf expects a property
   req.abTests = authInfo.abTests || {};
   const host = req.headers.host === config.contentOrigin ? config.contentOrigin : config.siteOrigin;
   req.backend = `${req.protocol}://${host}`;

--- a/test/server/clientlib.py
+++ b/test/server/clientlib.py
@@ -85,6 +85,26 @@ class ScreenshotsClient(object):
             {"id": shot_id, "expiration": str(seconds), "_csrf": csrf})
         resp.raise_for_status()
 
+    def set_title(self, url, new_title):
+        shot_id = self._get_id_from_url(url)
+        csrf = self.read_shot(url)["csrf"]
+        assert csrf, "No CSRF found"
+        resp = self.session.post(
+            urljoin(urljoin(self.backend, '/api/set-title/'), shot_id),
+            {"id": shot_id, "title": new_title, "_csrf": csrf})
+        resp.raise_for_status()
+
+    def edit_shot(self, url, edits):
+        shot_id = self._get_id_from_url(url)
+        csrf = self.read_shot(url)["csrf"]
+        assert csrf, "No CSRF found"
+        body = {"shotId": shot_id, "_csrf": csrf}
+        body.update(edits)
+        resp = self.session.post(
+            urljoin(self.backend, '/api/save-edit'),
+            body)
+        resp.raise_for_status()
+
     def delete_shot(self, url):
         shot_id = self._get_id_from_url(url)
         csrf = self.read_shot(url)["csrf"]
@@ -103,6 +123,7 @@ class ScreenshotsClient(object):
     def read_my_shots(self):
         resp = self.session.get(urljoin(self.backend, "/shots"))
         resp.raise_for_status()
+        return resp
 
     def search_shots(self, q):
         resp = self.session.get(urljoin(self.backend, "/shots"), params={"q": q})

--- a/test/server/test_csrf.py
+++ b/test/server/test_csrf.py
@@ -1,8 +1,6 @@
 from clientlib import ScreenshotsClient, screenshots_session
 from urlparse import urljoin, urlsplit
 import random
-import requests
-import json
 import re
 
 

--- a/test/server/test_csrf.py
+++ b/test/server/test_csrf.py
@@ -1,0 +1,117 @@
+from clientlib import ScreenshotsClient, screenshots_session
+from urlparse import urljoin, urlsplit
+import random
+import requests
+import json
+import re
+
+
+# Hack to make this predictable:
+random.seed(0)
+
+
+def test_leave_screenshots_with_valid_csrftoken_ok():
+    user = ScreenshotsClient()
+    user.login()
+
+    leave_resp = user.session.get(user.backend + "/leave-screenshots/")
+    assert leave_resp.status_code == 200
+    assert leave_resp.cookies.get('_csrf')
+
+    page = leave_resp.text
+    csrf_match = re.search(r'<input.*name="_csrf".*value="([^"]*)"', page)
+    csrf = csrf_match.group(1)
+    resp = user.session.post(
+        urljoin(user.backend, "/leave-screenshots/leave"),
+        json={"_csrf": csrf})
+    resp.raise_for_status()
+
+
+def test_leave_screenshots_with_invalid_csrftoken_fails():
+    user = ScreenshotsClient()
+    user.login()
+
+    leave_resp = user.session.get(user.backend + "/leave-screenshots/")
+    assert leave_resp.status_code == 200
+    assert leave_resp.cookies.get('_csrf')
+
+    resp = user.session.post(
+        urljoin(user.backend, "/leave-screenshots/leave"),
+        json={"_csrf": "bad-csrf-token"})
+
+    print(resp.text)
+    assert resp.status_code == 403
+
+    user.delete_account()
+
+
+def test_leave_screenshots_without_csrftoken_fails():
+    user = ScreenshotsClient()
+    user.login()
+
+    leave_resp = user.session.get(user.backend + "/leave-screenshots/")
+    assert leave_resp.status_code == 200
+    assert leave_resp.cookies.get('_csrf')
+
+    resp = user.session.post(
+        urljoin(user.backend, "/leave-screenshots/leave"))
+
+    print(resp.text)
+    assert resp.status_code == 403
+
+    user.delete_account()
+
+
+def test_leave_screenshots_with_get_fails():
+    user = ScreenshotsClient()
+    user.login()
+
+    leave_resp = user.session.get(user.backend + "/leave-screenshots/")
+    assert leave_resp.status_code == 200
+    assert leave_resp.cookies.get('_csrf')
+
+    page = leave_resp.text
+    csrf_match = re.search(r'<input.*name="_csrf".*value="([^"]*)"', page)
+    csrf = csrf_match.group(1)
+    resp = user.session.get(
+        urljoin(user.backend, "/leave-screenshots/leave"),
+        params={"_csrf": csrf})
+
+    assert resp.status_code == 404
+
+    user.delete_account()
+
+
+def test_get_settings_does_not_set_csrf_cookie():
+    with screenshots_session() as user:
+        resp = user.get_settings()  # GET /settings/
+        assert resp.status_code == 200
+        assert resp.cookies.get('_csrf', None) is None
+
+        # whether the 302 /settings/ -> /settings
+        # with set-cookie actually sets _csrf
+        # depends on the client
+        resp = user.get_uri(urljoin(user.backend, "/settings"))
+        assert resp.status_code == 200
+        assert resp.cookies.get('_csrf', None) is None
+
+
+def test_get_shot_sets_csrf_cookie():
+    with screenshots_session() as user:
+        shot_url = user.create_shot(docTitle="A_TEST_SITE_1", image_index=0)
+        shot_id = urlsplit(shot_url).path.strip("/")
+        user.create_shot(shot_id=shot_id, docTitle="A_TEST_SITE_2", image_index=1)
+
+        resp = user.session.get(shot_url)
+        resp.raise_for_status()
+        assert resp.cookies.get('_csrf')
+
+
+def test_get_my_shots_sets_csrf_cookie():
+    with screenshots_session() as user:
+        user.read_my_shots()  # raises on error
+        assert user.session.cookies.get('_csrf')
+
+
+if __name__ == "__main__":
+    pass

--- a/test/server/test_csrf.py
+++ b/test/server/test_csrf.py
@@ -1,4 +1,4 @@
-from clientlib import ScreenshotsClient, screenshots_session
+from clientlib import screenshots_session
 from urlparse import urljoin, urlsplit
 import random
 import re
@@ -8,76 +8,87 @@ import re
 random.seed(0)
 
 
+def assert_httponly_csrf_cookie(response, cookie_name='_csrf'):
+    "Test helper"
+    assert response.cookies.get(cookie_name)  # cookie exits
+    csrf_cookie = [c for c in response.cookies if c.name == cookie_name][0]
+    assert csrf_cookie.has_nonstandard_attr('HttpOnly')  # is HttpOnly
+
+
 def test_leave_screenshots_with_valid_csrftoken_ok():
-    user = ScreenshotsClient()
-    user.login()
+    with screenshots_session() as user:
+        leave_resp = user.session.get(user.backend + "/leave-screenshots/")
+        assert leave_resp.status_code == 200
+        assert_httponly_csrf_cookie(leave_resp)
 
-    leave_resp = user.session.get(user.backend + "/leave-screenshots/")
-    assert leave_resp.status_code == 200
-    assert leave_resp.cookies.get('_csrf')
-
-    page = leave_resp.text
-    csrf_match = re.search(r'<input.*name="_csrf".*value="([^"]*)"', page)
-    csrf = csrf_match.group(1)
-    resp = user.session.post(
-        urljoin(user.backend, "/leave-screenshots/leave"),
-        json={"_csrf": csrf})
-    resp.raise_for_status()
+        page = leave_resp.text
+        csrf_match = re.search(r'<input.*name="_csrf".*value="([^"]*)"', page)
+        csrf = csrf_match.group(1)
+        resp = user.session.post(
+            urljoin(user.backend, "/leave-screenshots/leave"),
+            json={"_csrf": csrf})
+        resp.raise_for_status()
 
 
 def test_leave_screenshots_with_invalid_csrftoken_fails():
-    user = ScreenshotsClient()
-    user.login()
+    with screenshots_session() as user:
+        leave_resp = user.session.get(user.backend + "/leave-screenshots/")
+        assert leave_resp.status_code == 200
+        assert_httponly_csrf_cookie(leave_resp)
 
-    leave_resp = user.session.get(user.backend + "/leave-screenshots/")
-    assert leave_resp.status_code == 200
-    assert leave_resp.cookies.get('_csrf')
+        resp = user.session.post(
+            urljoin(user.backend, "/leave-screenshots/leave"),
+            json={"_csrf": "bad-csrf-token"})
 
-    resp = user.session.post(
-        urljoin(user.backend, "/leave-screenshots/leave"),
-        json={"_csrf": "bad-csrf-token"})
-
-    print(resp.text)
-    assert resp.status_code == 403
-
-    user.delete_account()
+        print(resp.text)
+        assert resp.status_code == 403
 
 
 def test_leave_screenshots_without_csrftoken_fails():
-    user = ScreenshotsClient()
-    user.login()
+    with screenshots_session() as user:
+        leave_resp = user.session.get(user.backend + "/leave-screenshots/")
+        assert leave_resp.status_code == 200
+        assert_httponly_csrf_cookie(leave_resp)
 
-    leave_resp = user.session.get(user.backend + "/leave-screenshots/")
-    assert leave_resp.status_code == 200
-    assert leave_resp.cookies.get('_csrf')
+        resp = user.session.post(
+            urljoin(user.backend, "/leave-screenshots/leave"))
 
-    resp = user.session.post(
-        urljoin(user.backend, "/leave-screenshots/leave"))
-
-    print(resp.text)
-    assert resp.status_code == 403
-
-    user.delete_account()
+        print(resp.text)
+        assert resp.status_code == 403
 
 
 def test_leave_screenshots_with_get_fails():
-    user = ScreenshotsClient()
-    user.login()
+    with screenshots_session() as user:
+        leave_resp = user.session.get(user.backend + "/leave-screenshots/")
+        assert leave_resp.status_code == 200
+        assert_httponly_csrf_cookie(leave_resp)
 
-    leave_resp = user.session.get(user.backend + "/leave-screenshots/")
-    assert leave_resp.status_code == 200
-    assert leave_resp.cookies.get('_csrf')
+        page = leave_resp.text
+        csrf_match = re.search(r'<input.*name="_csrf".*value="([^"]*)"', page)
+        csrf = csrf_match.group(1)
+        resp = user.session.get(
+            urljoin(user.backend, "/leave-screenshots/leave"),
+            params={"_csrf": csrf})
 
-    page = leave_resp.text
-    csrf_match = re.search(r'<input.*name="_csrf".*value="([^"]*)"', page)
-    csrf = csrf_match.group(1)
-    resp = user.session.get(
-        urljoin(user.backend, "/leave-screenshots/leave"),
-        params={"_csrf": csrf})
+        assert resp.status_code == 404
 
-    assert resp.status_code == 404
 
-    user.delete_account()
+def test_leave_screenshots_with_duplicate_csrf_cookies_fails():
+    with screenshots_session() as user:
+        leave_resp = user.session.get(user.backend + "/leave-screenshots/")
+        print(leave_resp.cookies.get('_csrf'))
+        assert leave_resp.status_code == 200
+        assert_httponly_csrf_cookie(leave_resp)
+
+        page = leave_resp.text
+        csrf_match = re.search(r'<input.*name="_csrf".*value="([^"]*)"', page)
+        csrf = csrf_match.group(1)
+        resp = user.session.post(
+            urljoin(user.backend, "/leave-screenshots/leave"),
+            cookies={'_csrf': leave_resp.cookies.get('_csrf'),   # noqa: F601
+                         '_csrf': leave_resp.cookies.get('_csrf')},  # noqa: F601
+            json={"_csrf": csrf})
+        assert resp.status_code == 400
 
 
 def test_get_settings_does_not_set_csrf_cookie():
@@ -102,35 +113,207 @@ def test_get_shot_sets_csrf_cookie():
 
         resp = user.session.get(shot_url)
         resp.raise_for_status()
-        assert resp.cookies.get('_csrf')
+        assert_httponly_csrf_cookie(resp)
 
 
 def test_get_my_shots_sets_csrf_cookie():
     with screenshots_session() as user:
-        user.read_my_shots()  # raises on error
-        assert user.session.cookies.get('_csrf')
+        resp = user.read_my_shots()  # raises on error
+        assert_httponly_csrf_cookie(resp)
 
 
-def test_leave_screenshots_with_duplicate_csrf_cookies_fails():
-    user = ScreenshotsClient()
-    user.login()
+def test_delete_shot_with_valid_csrftoken_ok():
+    with screenshots_session() as user:
+        shot_url = user.create_shot(docTitle="A_TEST_SITE_1")
+        user.delete_shot(shot_url)  # reads and uses csrf token from shot page
 
-    leave_resp = user.session.get(user.backend + "/leave-screenshots/")
-    assert leave_resp.status_code == 200
-    assert leave_resp.cookies.get('_csrf')
 
-    page = leave_resp.text
-    csrf_match = re.search(r'<input.*name="_csrf".*value="([^"]*)"', page)
-    csrf = csrf_match.group(1)
-    resp = user.session.post(
-        urljoin(user.backend, "/leave-screenshots/leave"),
-        cookies={'_csrf': leave_resp.cookies.get('_csrf'),   # noqa: F601
-                 '_csrf': leave_resp.cookies.get('_csrf')},  # noqa: F601
-        json={"_csrf": csrf})
-    assert resp.status_code == 400
+def test_delete_shot_with_invalid_csrftoken_fails():
+    with screenshots_session() as user:
+        shot_url = user.create_shot(docTitle="A_TEST_SITE_1")
+        shot_id = user._get_id_from_url(shot_url)
+        resp = user.session.post(
+            urljoin(user.backend, "/api/delete-shot"),
+            {"id": shot_id, "_csrf": "bad-csrf-token"})
+        print(resp.text)
+        assert resp.status_code == 403  # Bad CSRF Token
 
-    user.delete_account()
+        user.delete_shot(shot_url)  # cleanup
+
+
+def test_delete_shot_without_csrftoken_fails():
+    with screenshots_session() as user:
+        shot_url = user.create_shot(docTitle="A_TEST_SITE_1")
+        shot_id = user._get_id_from_url(shot_url)
+        resp = user.session.post(
+            urljoin(user.backend, "/api/delete-shot"),
+            {"id": shot_id})
+        print(resp.text)
+        assert resp.status_code == 403  # Bad CSRF Token
+
+        user.delete_shot(shot_url)  # cleanup
+
+
+def test_shot_set_expiration_with_valid_csrftoken_ok():
+    with screenshots_session() as user:
+        shot_url = user.create_shot(docTitle="A_TEST_SITE_1")
+        user.set_expiration(shot_url, 290)  # reads and uses csrf token from shot page
+
+        user.delete_shot(shot_url)  # cleanup
+
+
+def test_shot_set_expiration_with_invalid_csrftoken_fails():
+    with screenshots_session() as user:
+        shot_url = user.create_shot(docTitle="A_TEST_SITE_1")
+        shot_id = user._get_id_from_url(shot_url)
+        resp = user.session.post(
+            urljoin(user.backend, "/api/set-expiration"),
+            {"id": shot_id, "expiration": "60", "_csrf": "bad-csrf-token"})
+        print(resp.text)
+        assert resp.status_code == 403  # Bad CSRF Token
+
+        user.delete_shot(shot_url)  # cleanup
+
+
+def test_shot_set_expiration_without_csrftoken_fails():
+    with screenshots_session() as user:
+        shot_url = user.create_shot(docTitle="A_TEST_SITE_1")
+        shot_id = user._get_id_from_url(shot_url)
+        resp = user.session.post(
+            urljoin(user.backend, "/api/set-expiration"),
+            {"id": shot_id, "expiration": "60"})
+        print(resp.text)
+        assert resp.status_code == 403  # Bad CSRF Token
+
+        user.delete_shot(shot_url)  # cleanup
+
+
+def test_shot_set_title_with_valid_csrftoken_ok():
+    with screenshots_session() as user:
+        shot_url = user.create_shot(docTitle="A_TEST_SITE_1")
+        user.set_title(shot_url, "New Screenshot Title")  # reads and uses csrf token from shot page
+
+        user.delete_shot(shot_url)  # cleanup
+
+
+def test_shot_set_title_with_invalid_csrftoken_fails():
+    with screenshots_session() as user:
+        shot_url = user.create_shot(docTitle="A_TEST_SITE_1")
+        shot_id = user._get_id_from_url(shot_url)
+        resp = user.session.post(
+            urljoin(urljoin(user.backend, "/api/set-title/"), shot_id),
+            {"id": shot_id, "title": "new title", "_csrf": "bad-csrf-token"})
+        print(resp.text)
+        assert resp.status_code == 403  # Bad CSRF Token
+
+        user.delete_shot(shot_url)  # cleanup
+
+
+def test_shot_set_title_without_csrftoken_fails():
+    with screenshots_session() as user:
+        shot_url = user.create_shot(docTitle="A_TEST_SITE_1")
+        shot_id = user._get_id_from_url(shot_url)
+        resp = user.session.post(
+            urljoin(urljoin(user.backend, "/api/set-title/"), shot_id),
+            {"id": shot_id, "title": "new title"})
+        print(resp.text)
+        assert resp.status_code == 403  # Bad CSRF Token
+
+        user.delete_shot(shot_url)  # cleanup
+
+# TODO: figure out why this takes a minute to run
+# def test_shot_edit_with_valid_csrftoken_ok():
+#     with screenshots_session() as user:
+#         shot_url = user.create_shot(docTitle="A_TEST_SITE_1")
+#         user.edit_shot(shot_url, dict(url="https://example.com/edited"))
+
+#         user.delete_shot(shot_url)  # cleanup
+
+
+def test_shot_edit_with_invalid_csrftoken_fails():
+    with screenshots_session() as user:
+        shot_url = user.create_shot(docTitle="A_TEST_SITE_1")
+        shot_id = user._get_id_from_url(shot_url)
+
+        body = {"shotId": shot_id, "_csrf": "bad-csrf-token"}
+        body.update(dict(url="https://example.com/edited"))
+        resp = user.session.post(
+            urljoin(user.backend, '/api/save-edit'),
+            body)
+        print(resp.text)
+        assert resp.status_code == 403  # Bad CSRF Token
+
+        user.delete_shot(shot_url)  # cleanup
+
+
+def test_shot_edit_without_csrftoken_fails():
+    with screenshots_session() as user:
+        shot_url = user.create_shot(docTitle="A_TEST_SITE_1")
+        shot_id = user._get_id_from_url(shot_url)
+
+        body = {"shotId": shot_id, "_csrf": "bad-csrf-token"}
+        body.update(dict(url="https://example.com/edited"))
+        resp = user.session.post(
+            urljoin(user.backend, '/api/save-edit'),
+            body)
+        print(resp.text)
+        assert resp.status_code == 403  # Bad CSRF Token
+
+        user.delete_shot(shot_url)  # cleanup
+
+
+def test_disconnect_device_with_valid_csrftoken_ok():
+    with screenshots_session() as user:
+        shot_url = user.create_shot(docTitle="A_TEST_SITE_1")
+        csrf = user.read_shot(shot_url)["csrf"]
+
+        resp = user.session.post(
+            urljoin(user.backend, '/api/disconnect-device/'),
+            {"_csrf": csrf})
+        print(resp.text)
+        assert resp.status_code == 200  # ok?
+
+        user.delete_shot(shot_url)  # cleanup
+
+
+def test_disconnect_device_with_invalid_csrftoken_fails():
+    with screenshots_session() as user:
+        resp = user.session.post(
+            urljoin(user.backend, '/api/disconnect-device/'),
+            {"_csrf": "bad-token"})
+        print(resp.text)
+        assert resp.status_code == 403  # Bad CSRF Token
+
+
+def test_disconnect_device_without_csrftoken_fails():
+    with screenshots_session() as user:
+        resp = user.session.post(
+            urljoin(user.backend, '/api/disconnect-device/'))
+        print(resp.text)
+        assert resp.status_code == 403  # Bad CSRF Token
 
 
 if __name__ == "__main__":
-    pass
+    test_leave_screenshots_with_valid_csrftoken_ok()
+    test_leave_screenshots_with_invalid_csrftoken_fails()
+    test_leave_screenshots_without_csrftoken_fails()
+    test_leave_screenshots_with_get_fails()
+    test_leave_screenshots_with_duplicate_csrf_cookies_fails()
+    test_get_settings_does_not_set_csrf_cookie()
+    test_get_shot_sets_csrf_cookie()
+    test_get_my_shots_sets_csrf_cookie()
+    test_delete_shot_with_valid_csrftoken_ok()
+    test_delete_shot_with_invalid_csrftoken_fails()
+    test_delete_shot_without_csrftoken_fails()
+    test_shot_set_expiration_with_valid_csrftoken_ok()
+    test_shot_set_expiration_with_invalid_csrftoken_fails()
+    test_shot_set_expiration_without_csrftoken_fails()
+    test_shot_set_title_with_valid_csrftoken_ok()
+    test_shot_set_title_with_invalid_csrftoken_fails()
+    test_shot_set_title_without_csrftoken_fails()
+    # test_shot_edit_with_valid_csrftoken_ok()
+    test_shot_edit_with_invalid_csrftoken_fails()
+    test_shot_edit_without_csrftoken_fails()
+    test_disconnect_device_with_valid_csrftoken_ok()
+    test_disconnect_device_with_invalid_csrftoken_fails()
+    test_disconnect_device_without_csrftoken_fails()


### PR DESCRIPTION
Rebased and slightly updated version of https://github.com/mozilla-services/screenshots/pull/3353

Rolling back the cookie key to the default of `_csrf` might have fixed https://github.com/mozilla-services/screenshots/pull/3353#issuecomment-325711537 for now.

Quickly ran some simple functional tests: reload the webextension, take a shot, edit it, change expiration, change title, delete it, delete account.

Didn't verify that the secure attr was set but hopefully that's OK to test in dev or stage.