### PR TITLE
clear csrf cookie on successful leave

### DIFF
--- a/server/src/pages/leave-screenshots/server.js
+++ b/server/src/pages/leave-screenshots/server.js
@@ -9,6 +9,9 @@ let app = express();
 exports.app = app;
 
 app.get("/", csrfProtection, function(req, res) {
+  if (req.query && req.query.complete !== undefined) {
+    res.clearCookie("_csrf");
+  }
   if (!req.deviceId) {
     res.status(403).send(req.getText("leavePageErrorAddonRequired"));
     return;


### PR DESCRIPTION
The csrf cookie shouldn't outlive the session and since we're using signed cookies we need to expire the cookie manually.