### PR TITLE
Fix #3468, remove browserAction

### DIFF
--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -236,13 +236,6 @@ let photonPageAction;
 // Does nothing otherwise.  Ideally, in the future, WebExtension page actions
 // and Photon page actions would be one in the same, but they aren't right now.
 function initPhotonPageAction(api, webExtension) {
-  // The MOZ_PHOTON_THEME ifdef got removed, but we need to support 55 and 56 as well,
-  // so check if the property exists *and* is false before bailing.
-  if (typeof AppConstants.MOZ_PHOTON_THEME != "undefined" && !AppConstants.MOZ_PHOTON_THEME) {
-    // Photon not supported.  Use the WebExtension's browser action.
-    return;
-  }
-
   let id = "screenshots";
   let port = null;
 
@@ -266,17 +259,6 @@ function initPhotonPageAction(api, webExtension) {
     },
   }));
 
-  // Remove the navbar button of the WebExtension's browser action.
-  let cuiWidgetID = "screenshots_mozilla_org-browser-action";
-  CustomizableUI.addListener({
-    onWidgetAfterCreation(wid, aArea) {
-      if (wid == cuiWidgetID) {
-        CustomizableUI.destroyWidget(cuiWidgetID);
-        CustomizableUI.removeListener(this);
-      }
-    },
-  });
-
   // Establish a port to the WebExtension side.
   api.browser.runtime.onConnect.addListener((listenerPort) => {
     if (listenerPort.name != "photonPageActionPort") {
@@ -297,14 +279,6 @@ function initPhotonPageAction(api, webExtension) {
         console.error("Unrecognized message:", message);
         break;
       }
-    });
-
-    // It's necessary to tell the WebExtension not to use its browser action,
-    // due to the CUI widget's removal.  Otherwise Firefox's WebExtension
-    // machinery throws exceptions.
-    port.postMessage({
-      type: "setUsePhotonPageAction",
-      value: true
     });
   });
 }

--- a/addon/install.rdf.template
+++ b/addon/install.rdf.template
@@ -7,7 +7,7 @@
     <em:targetApplication>
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id> <!--Firefox-->
-        <em:minVersion>51.0a1</em:minVersion>
+        <em:minVersion>57.0a1</em:minVersion>
         <em:maxVersion>*</em:maxVersion>
       </Description>
     </em:targetApplication>

--- a/addon/webextension/background/README.md
+++ b/addon/webextension/background/README.md
@@ -1,6 +1,6 @@
 These are all the files/modules for the background worker.  This is the higher-privileged WebExtension worker that has no interface.
 
-- `startBackground.js` handles the browserAction click event and context menu, and loads everything else on the first button of context menu click.
+- `startBackground.js` handles message port from bootstrap.js that sends the click event, handles the context menu, and loads everything else on the first button of context menu click.
 - `analytics.js` handles sending events to the server for use with GA.
 - `auth.js` handles the initial authentication call, and handles subsequent requests using that authentication.  It also informs `analytics.js` of any A/B tests so those can be submitted.
 - `clipboard.js` handles copying to the clipboard.

--- a/addon/webextension/background/main.js
+++ b/addon/webextension/background/main.js
@@ -18,16 +18,10 @@ this.main = (function() {
     if (!hasSeenOnboarding) {
       setIconActive(false, null);
       // Note that the branded name 'Firefox Screenshots' is not localized:
-      if (!startBackground.usePhotonPageAction) {
-        browser.browserAction.setTitle({
-          title: "Firefox Screenshots"
-        });
-      } else {
-        startBackground.photonPageActionPort.postMessage({
-          type: "setProperties",
-          title: "Firefox Screenshots"
-        });
-      }
+      startBackground.photonPageActionPort.postMessage({
+        type: "setProperties",
+        title: "Firefox Screenshots"
+      });
     }
   }).catch((error) => {
     log.error("Error getting hasSeenOnboarding:", error);
@@ -62,21 +56,10 @@ this.main = (function() {
     if ((!hasSeenOnboarding) && !active) {
       path = "icons/icon-starred-32-v2.svg";
     }
-    if (!startBackground.usePhotonPageAction) {
-      browser.browserAction.setIcon({path, tabId}).catch((error) => {
-        // FIXME: use errorCode
-        if (error.message && /Invalid tab ID/.test(error.message)) {
-          // This is a normal exception that we can ignore
-        } else {
-          catcher.unhandled(error);
-        }
-      });
-    } else {
-      startBackground.photonPageActionPort.postMessage({
-        type: "setProperties",
-        iconPath: path
-      });
-    }
+    startBackground.photonPageActionPort.postMessage({
+      type: "setProperties",
+      iconPath: path
+    });
   }
 
   function toggleSelector(tab) {
@@ -111,8 +94,7 @@ this.main = (function() {
     return /^about:(?:newtab|blank|home)/i.test(url) || /^resource:\/\/activity-streams\//i.test(url);
   }
 
-  // This is called by startBackground.js, directly in response to browser.browserAction.onClicked
-  // and clicks on the Photon page action
+  // This is called by startBackground.js, directly in response to clicks on the Photon page action
   exports.onClicked = catcher.watchFunction((tab) => {
     if (tab.incognito) {
       senderror.showError({
@@ -289,16 +271,10 @@ this.main = (function() {
     hasSeenOnboarding = true;
     catcher.watchPromise(browser.storage.local.set({hasSeenOnboarding}));
     setIconActive(false, null);
-    if (!startBackground.usePhotonPageAction) {
-      browser.browserAction.setTitle({
-        title: browser.i18n.getMessage("contextMenuLabel")
-      });
-    } else {
-      startBackground.photonPageActionPort.postMessage({
-        type: "setProperties",
-        title: browser.i18n.getMessage("contextMenuLabel")
-      });
-    }
+    startBackground.photonPageActionPort.postMessage({
+      type: "setProperties",
+      title: browser.i18n.getMessage("contextMenuLabel")
+    });
   });
 
   communication.register("abortFrameset", () => {

--- a/addon/webextension/background/startBackground.js
+++ b/addon/webextension/background/startBackground.js
@@ -1,6 +1,5 @@
 /* globals browser, main, communication */
 /* This file handles:
-     browser.browserAction.onClicked
      clicks on the Photon page action
      browser.contextMenus.onClicked
      browser.runtime.onMessage
@@ -30,14 +29,6 @@ this.startBackground = (function() {
   // Maximum milliseconds to wait before checking for migration possibility
   const CHECK_MIGRATION_DELAY = 2000;
 
-  browser.browserAction.onClicked.addListener((tab) => {
-    loadIfNecessary().then(() => {
-      main.onClicked(tab);
-    }).catch((error) => {
-      console.error("Error loading Screenshots:", error);
-    });
-  });
-
   browser.contextMenus.create({
     id: "create-screenshot",
     title: browser.i18n.getMessage("contextMenuLabel"),
@@ -60,16 +51,12 @@ this.startBackground = (function() {
     let hasSeenOnboarding = !!result.hasSeenOnboarding;
     if (!hasSeenOnboarding) {
       let path = "icons/icon-starred-32-v2.svg";
-      if (!usePhotonPageAction) {
-        browser.browserAction.setIcon({path});
-      } else {
-        iconPath = path;
-        if (photonPageActionPort) {
-          photonPageActionPort.postMessage({
-            type: "setProperties",
-            iconPath
-          });
-        }
+      iconPath = path;
+      if (photonPageActionPort) {
+        photonPageActionPort.postMessage({
+          type: "setProperties",
+          iconPath
+        });
       }
     }
   }).catch((error) => {
@@ -85,7 +72,6 @@ this.startBackground = (function() {
     return true;
   });
 
-  let usePhotonPageAction = false;
   let photonPageActionPort = null;
   initPhotonPageAction();
 
@@ -147,9 +133,6 @@ this.startBackground = (function() {
     photonPageActionPort = browser.runtime.connect({ name: "photonPageActionPort" });
     photonPageActionPort.onMessage.addListener((message) => {
       switch (message.type) {
-      case "setUsePhotonPageAction":
-        usePhotonPageAction = message.value;
-        break;
       case "click":
         loadIfNecessary().then(() => {
           main.onClicked(message.tab);
@@ -174,12 +157,6 @@ this.startBackground = (function() {
         enumerable: true,
         get() {
           return photonPageActionPort;
-        }
-      },
-      "usePhotonPageAction": {
-        enumerable: true,
-        get() {
-          return usePhotonPageAction;
         }
       }
     });

--- a/addon/webextension/background/startBackground.js
+++ b/addon/webextension/background/startBackground.js
@@ -50,8 +50,7 @@ this.startBackground = (function() {
   browser.storage.local.get(["hasSeenOnboarding"]).then((result) => {
     let hasSeenOnboarding = !!result.hasSeenOnboarding;
     if (!hasSeenOnboarding) {
-      let path = "icons/icon-starred-32-v2.svg";
-      iconPath = path;
+      iconPath = "icons/icon-starred-32-v2.svg";
       if (photonPageActionPort) {
         photonPageActionPort.postMessage({
           type: "setProperties",

--- a/addon/webextension/manifest.json.template
+++ b/addon/webextension/manifest.json.template
@@ -7,18 +7,11 @@
   "homepage_url": "https://github.com/mozilla-services/screenshots",
   "applications": {
     "gecko": {
-      "id": "screenshots@mozilla.org"
+      "id": "screenshots@mozilla.org",
+      "strict_min_version": "57.0a1"
     }
   },
   "default_locale": "en_US",
-  "browser_action": {
-    "default_icon": {
-      "16": "icons/icon-16-v2.svg",
-      "32": "icons/icon-32-v2.svg"
-    },
-    "default_title": "Firefox Screenshots",
-    "browser_style": false
-  },
   "background": {
     "scripts": [
       "build/buildSettings.js",

--- a/test/addon/browser_screenshots_ui_check.js
+++ b/test/addon/browser_screenshots_ui_check.js
@@ -1,6 +1,8 @@
 /* eslint disable */
 "use strict";
 
+const BUTTON_ID = "pageAction-panel-screenshots";
+
 function checkElements(expectPresent, l) {
   for (let id of l) {
     is(!!document.getElementById(id), expectPresent, "element " + id + (expectPresent ? " is" : " is not") + " present");
@@ -14,12 +16,9 @@ add_task(async function() {
     await promiseScreenshotsReset();
   });
 
-  let onPhoton = (typeof AppConstants.MOZ_PHOTON_THEME == "undefined") ||
-                 AppConstants.MOZ_PHOTON_THEME;
-  let id = onPhoton ? "pageAction-panel-screenshots" : "screenshots_mozilla_org-browser-action";
 
   await BrowserTestUtils.waitForCondition(
-    () => document.getElementById(id),
+    () => document.getElementById(BUTTON_ID),
     "Screenshots button should be present", 100, 100);
 
   checkElements(true, [id]);

--- a/test/addon/head.js
+++ b/test/addon/head.js
@@ -15,27 +15,14 @@ function promiseScreenshotsEnabled() {
   }
   info("Screenshots is not enabled");
   return new Promise((resolve, reject) => {
-    if (AppConstants.hasOwnProperty("MOZ_PHOTON_THEME") && !AppConstants.MOZ_PHOTON_THEME) {
-      let listener = {
-        onWidgetAfterCreation(widgetid) {
-          if (widgetid == "screenshots_mozilla_org-browser-action") {
-            info("screenshots_mozilla_org-browser-action button created");
-            CustomizableUI.removeListener(listener);
-            resolve(false);
-          }
-        }
+    let interval = setInterval(() => {
+      let action = PageActions.actionForID("screenshots");
+      if (action) {
+        info("screenshots page action created");
+        clearInterval(interval);
+        resolve(false);
       }
-      CustomizableUI.addListener(listener);
-    } else {
-      let interval = setInterval(() => {
-        let action = PageActions.actionForID("screenshots");
-        if (action) {
-          info("screenshots page action created");
-          clearInterval(interval);
-          resolve(false);
-        }
-      }, 100);
-    }
+    }, 100);
     info("Set Screenshots disabled pref to false.");
     Services.prefs.setBoolPref("extensions.screenshots.system-disabled", false);
   });
@@ -47,27 +34,14 @@ function promiseScreenshotsDisabled() {
     return Promise.resolve(true);
   }
   return new Promise((resolve, reject) => {
-    if (AppConstants.hasOwnProperty("MOZ_PHOTON_THEME") && !AppConstants.MOZ_PHOTON_THEME) {
-      let listener = {
-        onWidgetDestroyed(widgetid) {
-          if (widgetid == "screenshots_mozilla_org-browser-action") {
-            CustomizableUI.removeListener(listener);
-            info("screenshots_mozilla_org-browser-action destroyed");
-            resolve(false);
-          }
-        }
+    let interval = setInterval(() => {
+      let action = PageActions.actionForID("screenshots");
+      if (!action) {
+        info("screenshots page action removed");
+        clearInterval(interval);
+        resolve(false);
       }
-      CustomizableUI.addListener(listener);
-    } else {
-      let interval = setInterval(() => {
-        let action = PageActions.actionForID("screenshots");
-        if (!action) {
-          info("screenshots page action removed");
-          clearInterval(interval);
-          resolve(false);
-        }
-      }, 100);
-    }
+    }, 100);
     info("Set Screenshots disabled pref to true.");
     Services.prefs.setBoolPref("extensions.screenshots.system-disabled", true);
   });


### PR DESCRIPTION
This changes the add-on to require the Photon page action, with no fallback to a browserAction
- Removes test for Photon (assumes it is present)
- Removes bootstrap.js code that deletes the browserAction button
- Removes webextension code references to browserAction
- Removes Photon conditionals (i.e., assume it's always Photon)
- Make 57a1 the minimum version for the webextension/install.rdf