### PR TITLE
Fix #3493, send unauth'd /shots to /#tour

### DIFF
--- a/server/src/pages/shotindex/controller.js
+++ b/server/src/pages/shotindex/controller.js
@@ -33,7 +33,7 @@ exports.launch = function(m) {
     }
     let authTimeout = setTimeout(() => {
       // eslint-disable-next-line no-global-assign
-      location = location.origin;
+      location = location.origin + "/#tour";
     }, FIVE_SECONDS);
     window.wantsauth.addAuthDataListener((data) => {
       if (location.search.indexOf("reloaded") > -1) {


### PR DESCRIPTION
This lets a user who accesses Screenshots from the Library, but has never authenticated or used Screenshots, get redirected to an onboarding tour.

Also sends non-57 users to the normal onboarding without UITour