### PR TITLE
Csrf refactor

### DIFF
--- a/server/src/middleware/csrf.js
+++ b/server/src/middleware/csrf.js
@@ -55,6 +55,19 @@ const ignoreMethods = {
 };
 
 exports.csrfProtection = function(req, res, next) {
+  // The cookies library doesn't detect duplicates; check manually
+  let rawCookies = req.get("cookie") || "";
+  let pairs = rawCookies.split(";");
+  let csrfTokens = pairs.filter(item => item.match(/_csrf=/));
+  if (csrfTokens.length > 1) {
+    let exc = new Error("Duplicate CSRF cookies");
+    exc.headerValue = rawCookies;
+    captureRavenException(exc);
+    return simpleResponse(res, "Bad request", 400);
+  }
+  req.cookies._csrf = req.cookies.get("_csrf"); // csurf expects a property
+
+
   // check origin and referer headers
   if (!(ignoreMethods[req.method.toUpperCase()] || csrfHeadersValid(req))) {
     csrfInvalidHeaderResponse(req, res);
@@ -68,21 +81,6 @@ exports.csrfProtection = function(req, res, next) {
   }
   // also validate csrf token for unignored http methods
   csrfMiddleware(req, res, next);
-};
-
-exports.csrf = function(req, res, next) {
-  // The cookies library doesn't detect duplicates; check manually
-  let rawCookies = req.get("cookie") || "";
-  let pairs = rawCookies.split(";");
-  let csrfTokens = pairs.filter(item => item.match(/_csrf=/));
-  if (csrfTokens.length > 1) {
-    let exc = new Error("Duplicate CSRF cookies");
-    exc.headerValue = rawCookies;
-    captureRavenException(exc);
-    return simpleResponse(res, "Bad request", 400);
-  }
-  req.cookies._csrf = req.cookies.get("_csrf"); // csurf expects a property
-  next();
 };
 
 exports.csrfErrorResponse = function(err, req, res) {

--- a/server/src/pages/leave-screenshots/server.js
+++ b/server/src/pages/leave-screenshots/server.js
@@ -2,13 +2,12 @@ const express = require("express");
 const reactrender = require("../../reactrender");
 const { Shot } = require("../../servershot");
 const mozlog = require("../../logging").mozlog("leave-screenshots");
-const { csrfProtection } = require("../../middleware/csrf");
 
 let app = express();
 
 exports.app = app;
 
-app.get("/", csrfProtection, function(req, res) {
+app.get("/", function(req, res) {
   if (req.query && req.query.complete !== undefined) {
     res.clearCookie("_csrf");
   }
@@ -20,7 +19,7 @@ app.get("/", csrfProtection, function(req, res) {
   reactrender.render(req, res, page);
 });
 
-app.post("/leave", csrfProtection, function(req, res) {
+app.post("/leave", function(req, res) {
   if (!req.deviceId) {
     res.status(403).send(req.getText("leavePageErrorAddonRequired"));
   }

--- a/server/src/pages/settings/server.js
+++ b/server/src/pages/settings/server.js
@@ -1,12 +1,11 @@
 const express = require("express");
-const { csrfProtection } = require("../../middleware/csrf");
 const reactrender = require("../../reactrender");
 
 let app = express();
 
 exports.app = app;
 
-app.get("/", csrfProtection, function(req, res) {
+app.get("/", function(req, res) {
   if (!req.deviceId) {
     res.status(403).send("You must have Screenshots installed");
     return;

--- a/server/src/pages/shot/server.js
+++ b/server/src/pages/shot/server.js
@@ -1,5 +1,4 @@
 const express = require("express");
-const { csrfProtection } = require("../../middleware/csrf");
 const { Shot } = require("../../servershot");
 const { notFound } = require("../../pages/not-found/server");
 const reactrender = require("../../reactrender");
@@ -9,7 +8,7 @@ let app = express();
 
 exports.app = app;
 
-app.get("/:id/:domain", csrfProtection, function(req, res) {
+app.get("/:id/:domain", function(req, res) {
   let shotId = `${req.params.id}/${req.params.domain}`;
   Shot.get(req.backend, shotId).then((shot) => {
     let noSuchShot = !shot;

--- a/server/src/pages/shotindex/server.js
+++ b/server/src/pages/shotindex/server.js
@@ -1,5 +1,4 @@
 const express = require("express");
-const { csrfProtection } = require("../../middleware/csrf");
 const reactrender = require("../../reactrender");
 const { Shot } = require("../../servershot");
 const mozlog = require("../../logging").mozlog("shotindex");
@@ -8,7 +7,7 @@ let app = express();
 
 exports.app = app;
 
-app.get("/", csrfProtection, function(req, res) {
+app.get("/", function(req, res) {
   if (!req.deviceId) {
     _render();
     return;

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -31,7 +31,7 @@ const dbschema = require("./dbschema");
 const express = require("express");
 const bodyParser = require('body-parser');
 const contentDisposition = require("content-disposition");
-const { csrf, csrfProtection, csrfErrorResponse } = require("./middleware/csrf");
+const { csrfProtection, csrfErrorResponse } = require("./middleware/csrf");
 const morgan = require("morgan");
 const linker = require("./linker");
 const { randomBytes } = require("./helpers");
@@ -228,7 +228,6 @@ app.use(function(req, res, next) {
 
 // NOTE - the csrf middleware should come after the middleware that
 // assigns req.cookies.
-app.use(csrf);
 app.use(csrfProtection);
 
 function decodeAuthHeader(header) {

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -229,6 +229,7 @@ app.use(function(req, res, next) {
 // NOTE - the csrf middleware should come after the middleware that
 // assigns req.cookies.
 app.use(csrf);
+app.use(csrfProtection);
 
 function decodeAuthHeader(header) {
   /** Decode a string header in the format {deviceId}:{deviceIdSig};abtests={b64thing}:{sig} */
@@ -450,7 +451,7 @@ app.post("/event", function(req, res) {
   });
 });
 
-app.post("/api/register", csrfProtection, function(req, res) {
+app.post("/api/register", function(req, res) {
   let vars = req.body;
   let canUpdate = vars.deviceId === req.deviceId;
   if (!vars.deviceId) {
@@ -523,7 +524,7 @@ function sendAuthInfo(req, res, params) {
 }
 
 
-app.post("/api/login", csrfProtection, function(req, res) {
+app.post("/api/login", function(req, res) {
   let vars = req.body;
   let deviceInfo = {};
   try {
@@ -667,7 +668,7 @@ app.get("/data/:id/:domain", function(req, res) {
   });
 });
 
-app.post("/api/delete-shot", csrfProtection, function(req, res) {
+app.post("/api/delete-shot", function(req, res) {
   if (!req.deviceId) {
     sendRavenMessage(req, "Attempt to delete shot without login");
     simpleResponse(res, "Not logged in", 401);
@@ -685,7 +686,7 @@ app.post("/api/delete-shot", csrfProtection, function(req, res) {
   });
 });
 
-app.post("/api/disconnect-device", csrfProtection, function(req, res) {
+app.post("/api/disconnect-device", function(req, res) {
   if (!req.deviceId) {
     sendRavenMessage(req, "Attempt to disconnect without login");
     simpleResponse(res, "Not logged in", 401);
@@ -704,7 +705,7 @@ app.post("/api/disconnect-device", csrfProtection, function(req, res) {
   });
 });
 
-app.post("/api/set-title/:id/:domain", csrfProtection, function(req, res) {
+app.post("/api/set-title/:id/:domain", function(req, res) {
   let shotId = `${req.params.id}/${req.params.domain}`;
   let userTitle = req.body.title;
   if (userTitle === undefined) {
@@ -730,7 +731,7 @@ app.post("/api/set-title/:id/:domain", csrfProtection, function(req, res) {
   });
 });
 
-app.post("/api/save-edit", csrfProtection, function(req, res) {
+app.post("/api/save-edit", function(req, res) {
   let vars = req.body;
   if (!req.deviceId) {
     sendRavenMessage(req, "Attempt to edit shot without login");
@@ -760,7 +761,7 @@ app.post("/api/save-edit", csrfProtection, function(req, res) {
   })
 });
 
-app.post("/api/set-expiration", csrfProtection, function(req, res) {
+app.post("/api/set-expiration", function(req, res) {
   if (!req.deviceId) {
     sendRavenMessage(req, "Attempt to set expiration without login");
     simpleResponse(res, "Not logged in", 401);


### PR DESCRIPTION
Changes:

* Default to using csrf middleware for all routes
* Remove route specific csrf middleware
* combine csrf and csrfProtection middleware

If new routes need to skip csrf protection for some reason we can add their URI paths to `isCsrfExemptPath` in middleware/csrf.

r? @6a68

