### PR TITLE
Bump max image dimensions to canvas limit

### DIFF
--- a/addon/webextension/selector/uicontrol.js
+++ b/addon/webextension/selector/uicontrol.js
@@ -45,8 +45,9 @@ this.uicontrol = (function() {
 
   const { watchFunction, watchPromise } = catcher;
 
-  const MAX_PAGE_HEIGHT = 5000;
-  const MAX_PAGE_WIDTH = 5000;
+  // In Firefox, a single canvas image cannot exceed 32767 px in either direction:
+  const MAX_PAGE_HEIGHT = 32767;
+  const MAX_PAGE_WIDTH = 32767;
   // An autoselection smaller than these will be ignored entirely:
   const MIN_DETECT_ABSOLUTE_HEIGHT = 10;
   const MIN_DETECT_ABSOLUTE_WIDTH = 30;

--- a/test/server/clientlib.py
+++ b/test/server/clientlib.py
@@ -61,7 +61,7 @@ class ScreenshotsClient(object):
         resp.raise_for_status()
         page = resp.text
         clip_match = re.search(r'<img id="clipImage"[^>]*src="([^"]+)"', page)
-        clip_url = clip_content = None
+        clip_url = clip_content = clip_content_type = None
         if clip_match:
             clip_url = clip_match.group(1)
             if clip_url:


### PR DESCRIPTION
It turns out that canvas.toDataURL() has a limit of 32767 pixels in any direction (see [bug 1282074](https://bugzil.la/1282074) for details).

Bumping the max height/width to those dimensions, I created some test images from facebook, imgur, and giphy. Imgur came in biggest, around 12 MB. Seems like we can safely bump up the pixel limit without hitting the server max of 25 MB per image.

I tried bumping quality up to 1.0 but couldn't see any significant quality improvement. Smallish text on Facebook is reasonably legible in either case. I'll attach a couple example images to this PR.