### PR TITLE
Use pytest.mark to suppress the test_file_management tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -33,7 +33,7 @@ test:
     # server tests
     - ./bin/test-request put '{}'
     - ./bin/load_test_exercise.py http://localhost:10080
-    - npm run test:server -- --ignore=test_file_management.py
+    - npm run test:server
     # run zap baseline against the server
     - docker pull owasp/zap2docker-weekly
     # || true to temporarily disable this from making the tests fail:

--- a/test/server/test_file_management.py
+++ b/test/server/test_file_management.py
@@ -4,6 +4,7 @@ import clientlib
 import time
 import atexit
 from sarge import Capture, run
+import pytest
 
 SERVER_URL = "http://localhost:10180"
 
@@ -22,6 +23,7 @@ def make_session():
     return session
 
 
+@pytest.mark.skip(reason="Too slow to run")
 def test_s3_upload():
     restart_server()
     session = make_session()
@@ -31,6 +33,7 @@ def test_s3_upload():
     assert read_file(page["clip_url"]) == get_url(page["clip_url"])
 
 
+@pytest.mark.skip(reason="Too slow to run")
 def test_s3_expire():
     restart_server()
     session = make_session()
@@ -46,6 +49,7 @@ def test_s3_expire():
     get_url(shot_url, expect=200)
 
 
+@pytest.mark.skip(reason="Too slow to run")
 def test_s3_delete():
     restart_server()
     session = make_session()
@@ -58,6 +62,7 @@ def test_s3_delete():
     assert read_file(page["clip_url"]) is None
 
 
+@pytest.mark.skip(reason="Too slow to run")
 def test_s3_delete_after_expire():
     restart_server(DEFAULT_EXPIRATION=1)
     session = make_session()
@@ -74,6 +79,7 @@ def test_s3_delete_after_expire():
     assert read_file(page["clip_url"]) is None
 
 
+@pytest.mark.skip(reason="Too slow to run")
 def test_s3_final_expire():
     restart_server(EXPIRED_RETENTION_TIME=1, CHECK_DELETED_INTERVAL="0.1")
     session = make_session()


### PR DESCRIPTION
The tests are too slow to run in any normal process, so this will keep developers from getting caught up in them.