### PR TITLE
Use correct latest commit in __version__ endpoint

### DIFF
--- a/bin/build-scripts/write_build_time.py
+++ b/bin/build-scripts/write_build_time.py
@@ -10,4 +10,4 @@ print 'exports.timestamp = %i' % int(now * 1000)
 
 import subprocess
 print 'exports.gitrevision = %r' % subprocess.check_output(
-    ["git", "describe", "--always"]).strip()
+    ["git", "describe", "--tags", "--always"]).strip()


### PR DESCRIPTION
Works for me locally; note the 'After' commit points to the commit in this PR.

Before:

```json
{
  "source": "https://github.com/mozilla-services/screenshots/",
  "description": "Firefox Screenshots application server",
  "version": "20.0.0",
  "buildDate": "September 21, 2017 17:39:13 UTC",
  "commit": "8.1.0-1574-gc21f3d38",
  "contentOrigin": "localhost:10080",
  "commitLog": "https://github.com/mozilla-services/screenshots/commits/8.1.0-1574-gc21f3d38",
  "unincludedCommits": "https://github.com/mozilla-services/screenshots/compare/8.1.0-1574-gc21f3d38...master",
  "dbSchemaVersion": 20
}
```

After:
```json
{
  "source": "https://github.com/mozilla-services/screenshots/",
  "description": "Firefox Screenshots application server",
  "version": "20.0.0",
  "buildDate": "September 21, 2017 18:14:38 UTC",
  "commit": "20.0.0-42-g2b7a703a",
  "contentOrigin": "localhost:10080",
  "commitLog": "https://github.com/mozilla-services/screenshots/commits/20.0.0-42-g2b7a703a",
  "unincludedCommits": "https://github.com/mozilla-services/screenshots/compare/20.0.0-42-g2b7a703a...master",
  "dbSchemaVersion": 20
}
```