### PR TITLE
Bug fix for #3513, create proper extension for downloads

### DIFF
--- a/addon/webextension/selector/shooter.js
+++ b/addon/webextension/selector/shooter.js
@@ -178,6 +178,17 @@ this.shooter = (function() { // eslint-disable-line no-unused-vars
         });
     }
     catcher.watchPromise(promise.then((dataUrl) => {
+      let type = blobConverters.getTypeFromDataUrl(dataUrl);
+      type = type ? type.split("/")[1] : null;
+      shotObject.delAllClips();
+      shotObject.addClip({
+        createdDate: Date.now(),
+        image: {
+          url: dataUrl,
+          type,
+          location: selectedPos
+        }
+      });
       ui.triggerDownload(dataUrl, shotObject.filename);
       uicontrol.deactivate();
     }));


### PR DESCRIPTION
The clip object is used to inform the download filename, so we need to add a clip before generating the filename