### PR TITLE
Fix #3491, stop Screenshots in Private Browsing

### DIFF
--- a/addon/webextension/background/startBackground.js
+++ b/addon/webextension/background/startBackground.js
@@ -135,7 +135,9 @@ this.startBackground = (function() {
       switch (message.type) {
       case "click":
         loadIfNecessary().then(() => {
-          main.onClicked(message.tab);
+          return browser.tabs.get(message.tab.id);
+        }).then((tab) => {
+          main.onClicked(tab);
         }).catch((error) => {
           console.error("Error loading Screenshots:", error);
         });


### PR DESCRIPTION
bootstrap.js sends the tab ID with the Photon page action, but it doesn't have the complete set of information that the WebExtension tab object has