### PR TITLE
Fix #3174, make selector view usable on high contrast themes

### DIFF
--- a/addon/webextension/selector/ui.js
+++ b/addon/webextension/selector/ui.js
@@ -336,7 +336,7 @@ this.ui = (function() { // eslint-disable-line no-unused-vars
                 <style>${substitutedCss}</style>
                 <title></title>
               </head>
-              <body>
+              <body id="preview-frame">
                 <div class="preview-overlay">
                   <div class="preview-image">
                     <div class="preview-buttons">

--- a/static/css/inline-selection.scss
+++ b/static/css/inline-selection.scss
@@ -21,7 +21,7 @@ $handle-mover-offset: -1px;
 $mover-size: $mover-outer + $mover-inner;
 $overlay-z-index: 9999999999;
 
-$modal-color: rgba(0, 0, 0, 0.7);
+$modal-color: rgb(0, 0, 0);
 $very-light-grey: #ededed;
 
 
@@ -45,7 +45,8 @@ $very-light-grey: #ededed;
 
 .hover-highlight {
   animation: fade-in 125ms forwards $bezier;
-  background: rgba(255, 255, 255, 0.2);
+  background: rgb(255, 255, 255);
+  opacity: 0.2;
   border-radius: 1px;
   pointer-events: none;
   position: absolute;
@@ -177,6 +178,7 @@ $very-light-grey: #ededed;
 
 .bghighlight {
   background-color: $modal-color;
+  opacity: 0.7;
   position: absolute;
   z-index: $overlay-z-index;
 }
@@ -184,6 +186,7 @@ $very-light-grey: #ededed;
 .preview-overlay {
   align-items: center;
   background-color: $modal-color;
+  opacity: 0.7;
   display: flex;
   height: 100%;
   justify-content: center;
@@ -194,6 +197,10 @@ $very-light-grey: #ededed;
   top: 0;
   width: 100%;
   z-index: $overlay-z-index;
+
+  body#preview-frame & {
+    opacity: 1;
+  }
 }
 
 .highlight {
@@ -400,6 +407,7 @@ $very-light-grey: #ededed;
   text-align: center;
   padding-top: 20px;
   width: 400px;
+  opacity: 1.0;
 }
 
 .myshots-all-buttons-container {


### PR DESCRIPTION
For whatever reason, separating out the opacity bit from the background color partially resolved the problems with the selector interface. Props to MattN for suggesting this workaround.

Unfortunately, something about how the `.hover-highlight` layers translucent white on top of translucent black causes it to remain fully opaque. The click-and-drag selection works fine. Turns out that background images aren't displayed on High Contrast mode on Windows, so we could use a tiled background image for the `hover-highlight`. Another, more complex hack, would be to set a dummy background image (`background-image: url('#')` suggested [on SO](https://stackoverflow.com/questions/16213395/windows-7-high-contrast-theme-overrides-website-colors-in-firefox)), check if the background-image property is missing with JS, and if it's missing, remove the background styles from `.hover-highlight`. I dunno, though.

Might poke at this a little more on Monday, but at least this is an improvement. 

### Here's wikipedia in HC mode:

<img width="1169" alt="screen shot 2017-09-22 at 4 23 25 pm" src="https://user-images.githubusercontent.com/96396/30767712-1acc9528-9fb4-11e7-952f-863d23aef169.png">



### Here's the screenshots selection flow before:

<img width="1169" alt="screen shot 2017-09-22 at 4 23 57 pm" src="https://user-images.githubusercontent.com/96396/30767713-1accdf24-9fb4-11e7-9241-396d02262b27.png">
<img width="1169" alt="screen shot 2017-09-22 at 4 24 06 pm" src="https://user-images.githubusercontent.com/96396/30767716-1ad011bc-9fb4-11e7-8216-721634446962.png">


### Screenshots selection flow, after:

<img width="1169" alt="screen shot 2017-09-22 at 4 27 25 pm" src="https://user-images.githubusercontent.com/96396/30767717-1ad2571a-9fb4-11e7-9cda-97b58b716148.png">

Still visibility problems with the DOM node auto-selector:

<img width="1169" alt="screen shot 2017-09-22 at 4 27 42 pm" src="https://user-images.githubusercontent.com/96396/30767715-1acf87f6-9fb4-11e7-8818-0ecccc79f889.png">

But clicking and dragging is a lot more usable:

<img width="1169" alt="screen shot 2017-09-22 at 4 27 56 pm" src="https://user-images.githubusercontent.com/96396/30767714-1acf1244-9fb4-11e7-80dc-2e92882e853a.png">

Added a rule to make the preview frame's opacity 1.0, so that the Visible / Full Page image preview is fully opaque:

<img width="1169" alt="screen shot 2017-09-22 at 4 28 06 pm" src="https://user-images.githubusercontent.com/96396/30767718-1aebb4c6-9fb4-11e7-873f-7bae5b6e69a2.png">
