### PR TITLE
Put limits on uses of string.split

### DIFF
--- a/addon/webextension/blobConverters.js
+++ b/addon/webextension/blobConverters.js
@@ -2,7 +2,7 @@ this.blobConverters = (function() {
   let exports = {};
 
   exports.dataUrlToBlob = function(url) {
-    const binary = atob(url.split(',')[1]);
+    const binary = atob(url.split(',', 2)[1]);
     let contentType = exports.getTypeFromDataUrl(url);
     if (contentType != "image/png" && contentType != "image/jpeg") {
       contentType = "image/png";
@@ -13,9 +13,9 @@ this.blobConverters = (function() {
   };
 
   exports.getTypeFromDataUrl = function(url) {
-    let contentType = url.split(',')[0];
-    contentType = contentType.split(';')[0];
-    contentType = contentType.split(':')[1];
+    let contentType = url.split(',', 1)[0];
+    contentType = contentType.split(';', 1)[0];
+    contentType = contentType.split(':', 2)[1];
     return contentType;
   };
 

--- a/addon/webextension/selector/shooter.js
+++ b/addon/webextension/selector/shooter.js
@@ -109,7 +109,7 @@ this.shooter = (function() { // eslint-disable-line no-unused-vars
     }
     let dataUrl = url || screenshotPage(selectedPos, captureType);
     let type = blobConverters.getTypeFromDataUrl(dataUrl);
-    type = type ? type.split("/")[1] : null;
+    type = type ? type.split("/", 2)[1] : null;
     if (dataUrl) {
       imageBlob = blobConverters.dataUrlToBlob(dataUrl);
       shotObject.delAllClips();
@@ -179,7 +179,7 @@ this.shooter = (function() { // eslint-disable-line no-unused-vars
     }
     catcher.watchPromise(promise.then((dataUrl) => {
       let type = blobConverters.getTypeFromDataUrl(dataUrl);
-      type = type ? type.split("/")[1] : null;
+      type = type ? type.split("/", 2)[1] : null;
       shotObject.delAllClips();
       shotObject.addClip({
         createdDate: Date.now(),


### PR DESCRIPTION
This only covers cases in the JPEG commits, to keep the resulting diff minimal