### PR TITLE
[Do not merge] Export filename fix to Firefox

### DIFF
--- a/shared/shot.js
+++ b/shared/shot.js
@@ -365,7 +365,7 @@ class AbstractShot {
   get filename() {
     let filenameTitle = this.title;
     let date = new Date(this.createdDate);
-    filenameTitle = filenameTitle.replace(/[:\\<>/!@&*.|\n\r\t]/g, " ");
+    filenameTitle = filenameTitle.replace(/[:\\<>/!@&?"*.|\n\r\t]/g, " ");
     filenameTitle = filenameTitle.replace(/\s{1,4000}/g, " ");
     let clipFilename = `Screenshot-${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()} ${filenameTitle}`;
     const clipFilenameBytesSize = clipFilename.length * 2; // JS STrings are UTF-16


### PR DESCRIPTION
Export tracking. See [Bug 1403665](https://bugzilla.mozilla.org/show_bug.cgi?id=1403665). Note test failure is related to nsp, but only applies to the server component, which is not relevant here.

---

Fix #3517, remove " and ? from filenames