### PR TITLE
Fix: remove control characters from filenames

### DIFF
--- a/shared/shot.js
+++ b/shared/shot.js
@@ -365,7 +365,8 @@ class AbstractShot {
   get filename() {
     let filenameTitle = this.title;
     let date = new Date(this.createdDate);
-    filenameTitle = filenameTitle.replace(/[:\\<>/!@&?"*.|\n\r\t]/g, " ");
+    // eslint-disable-next-line no-control-regex
+    filenameTitle = filenameTitle.replace(/[:\\<>/!@&?"*.|\x00-\x1F]/g, " ");
     filenameTitle = filenameTitle.replace(/\s{1,4000}/g, " ");
     let clipFilename = `Screenshot-${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()} ${filenameTitle}`;
     const clipFilenameBytesSize = clipFilename.length * 2; // JS STrings are UTF-16


### PR DESCRIPTION
This patch removes all control characters (0x00...0x1F) from filenames, not only "\n\r\t".

They are not allowed in Microsoft Windows file names, see:
https://msdn.microsoft.com/en-us/library/aa365247(VS.85).aspx#naming_conventions

And possibly in other systems:
https://en.wikipedia.org/wiki/Filename#Reserved_characters_and_words