### PR TITLE
Fix #3372, run server unit tests with npm run test

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "postlint": "nsp check -o summary",
     "nsp": "nsp check",
     "posttest": "npm run lint",
-    "test": "make bootstrap_zip && mocha test/",
+    "test": "make bootstrap_zip && mocha test/ test/server/unit/*",
     "test:selenium": "make bootstrap_zip && mocha test/test.js",
     "test:server": "make .venv && cd test/server && ../../.venv/bin/pytest",
     "make_versions_exact": "node bin/build-scripts/make_versions_exact.js",

--- a/test/server/unit/l10n-test.js
+++ b/test/server/unit/l10n-test.js
@@ -1,0 +1,20 @@
+const assert = require('assert');
+const l10n = require('../../../server/src/l10n.js');
+
+/* globals describe, it */
+
+describe('l10n', () => {
+  before((done) => {
+    l10n.init().then((result) => { done() }).catch(done);
+  });
+  describe('getUserLocales', () => {
+    it('should fall back to en-US if requested language has no localization', () => {
+      let locales = l10n.getUserLocales(['yo-LO']);
+      assert.ok(locales.includes('en-US'));
+    });
+    it('should fall back to en-US if requested language is missing', () => {
+      let locales = l10n.getUserLocales([]);
+      assert.ok(locales.includes('en-US'));
+    });
+  });
+});

--- a/test/server/unit/middleware/l10n-test.js
+++ b/test/server/unit/middleware/l10n-test.js
@@ -17,17 +17,5 @@ describe('l10n middleware', () => {
       assert(results.length === 1);
       assert.equal('en-US', results[0]);
     });
-    it('should return ["en-US"] if Accept-Language header value is "en-CA"', () => {
-      let mockRequest = { headers: { 'accept-language': 'en-CA' }};
-      let results = l10n.getLanguages(mockRequest);
-      assert(results.length === 1);
-      assert.equal('en-US', results[0]);
-    });
-    it('should return ["en-US"] if Accept-Language header value is "en"', () => {
-      let mockRequest = { headers: { 'accept-language': 'en' }};
-      let results = l10n.getLanguages(mockRequest);
-      assert(results.length === 1);
-      assert.equal('en-US', results[0]);
-    });
   });
 });


### PR DESCRIPTION
Note tests have broken when they weren't being run.

I'm not that clear on how the tests *should* act, so I'm not sure how to fix. Errors:

```
  1) l10n middleware getLanguage function (Accept-Language header parsing) should return ["en-US"] if Accept-Language header value is "en-CA":

      AssertionError: 'en-US' == 'en-CA'
      + expected - actual

      -en-US
      +en-CA
      
      at Context.it (test/server/unit/middleware/l10n-test.js:24:14)

  2) l10n middleware getLanguage function (Accept-Language header parsing) should return ["en-US"] if Accept-Language header value is "en":

      AssertionError: 'en-US' == 'en'
      + expected - actual

      -en-US
      +en
      
      at Context.it (test/server/unit/middleware/l10n-test.js:30:14)
```