### PR TITLE
Better hcm detection

### DIFF
--- a/addon/webextension/selector/ui.js
+++ b/addon/webextension/selector/ui.js
@@ -76,6 +76,21 @@ this.ui = (function() { // eslint-disable-line no-unused-vars
     }
   }
 
+  function highContrastCheck(win) {
+    let result, doc, el;
+    doc = win.document;
+    el = doc.createElement("div");
+    el.style.backgroundImage = "url('#')";
+    el.style.display = "none";
+    doc.body.appendChild(el);
+    let computed = win.getComputedStyle(el);
+    // When Windows is in High Contrast mode, Firefox replaces background
+    // image URLs with the string "none".
+    result = computed && computed.backgroundImage === "none";
+    doc.body.removeChild(el);
+    return result;
+  }
+
   function initializeIframe() {
     let el = document.createElement("iframe");
     el.src = browser.extension.getURL("blank.html");
@@ -140,6 +155,9 @@ this.ui = (function() { // eslint-disable-line no-unused-vars
     unhide() {
       this.updateElementSize();
       this.element.style.display = "";
+      if (highContrastCheck(this.element.contentWindow)) {
+        this.element.contentDocument.body.classList.add("hcm");
+      }
       this.initSizeWatch();
       this.element.focus();
     },
@@ -290,6 +308,9 @@ this.ui = (function() { // eslint-disable-line no-unused-vars
       window.addEventListener("scroll", watchFunction(assertIsTrusted(this.onScroll)));
       window.addEventListener("resize", this.onResize, true);
       this.element.style.display = "";
+      if (highContrastCheck(this.element.contentWindow)) {
+        this.element.contentDocument.body.classList.add("hcm");
+      }
       this.element.focus();
     },
 

--- a/addon/webextension/selector/ui.js
+++ b/addon/webextension/selector/ui.js
@@ -336,7 +336,7 @@ this.ui = (function() { // eslint-disable-line no-unused-vars
                 <style>${substitutedCss}</style>
                 <title></title>
               </head>
-              <body id="preview-frame">
+              <body>
                 <div class="preview-overlay">
                   <div class="preview-image">
                     <div class="preview-buttons">

--- a/static/css/inline-selection.scss
+++ b/static/css/inline-selection.scss
@@ -60,6 +60,11 @@ $very-light-grey: #ededed;
     right: 0;
     top: 0;
   }
+
+  body.hcm & {
+    background-color: rgb(255, 255, 255);
+    opacity: 0.2;
+  }
 }
 
 .mover-target.direction-topLeft {
@@ -179,6 +184,10 @@ $very-light-grey: #ededed;
   background-color: $modal-color;
   position: absolute;
   z-index: $overlay-z-index;
+  body.hcm & {
+    background-color: rgb(0, 0, 0);
+    opacity: 0.7;
+  }
 }
 
 .preview-overlay {
@@ -194,6 +203,10 @@ $very-light-grey: #ededed;
   top: 0;
   width: 100%;
   z-index: $overlay-z-index;
+  body.hcm & {
+    background-color: rgb(0, 0, 0);
+    opacity: 0.7;
+  }
 }
 
 .highlight {
@@ -203,6 +216,10 @@ $very-light-grey: #ededed;
   cursor: move;
   position: absolute;
   z-index: $overlay-z-index;
+  body.hcm & {
+    border: 2px dashed rgb(255, 255, 255);
+    opacity: 1.0;
+  }
 }
 
 .highlight-buttons {

--- a/static/css/inline-selection.scss
+++ b/static/css/inline-selection.scss
@@ -21,7 +21,7 @@ $handle-mover-offset: -1px;
 $mover-size: $mover-outer + $mover-inner;
 $overlay-z-index: 9999999999;
 
-$modal-color: rgb(0, 0, 0);
+$modal-color: rgba(0, 0, 0, 0.7);
 $very-light-grey: #ededed;
 
 
@@ -45,8 +45,7 @@ $very-light-grey: #ededed;
 
 .hover-highlight {
   animation: fade-in 125ms forwards $bezier;
-  background: rgb(255, 255, 255);
-  opacity: 0.2;
+  background: rgba(255, 255, 255, 0.2);
   border-radius: 1px;
   pointer-events: none;
   position: absolute;
@@ -178,7 +177,6 @@ $very-light-grey: #ededed;
 
 .bghighlight {
   background-color: $modal-color;
-  opacity: 0.7;
   position: absolute;
   z-index: $overlay-z-index;
 }
@@ -186,7 +184,6 @@ $very-light-grey: #ededed;
 .preview-overlay {
   align-items: center;
   background-color: $modal-color;
-  opacity: 0.7;
   display: flex;
   height: 100%;
   justify-content: center;
@@ -197,10 +194,6 @@ $very-light-grey: #ededed;
   top: 0;
   width: 100%;
   z-index: $overlay-z-index;
-
-  body#preview-frame & {
-    opacity: 1;
-  }
 }
 
 .highlight {
@@ -407,7 +400,6 @@ $very-light-grey: #ededed;
   text-align: center;
   padding-top: 20px;
   width: 400px;
-  opacity: 1.0;
 }
 
 #imageCroppedWarning {


### PR DESCRIPTION
Sadly, the `-ms-high-contrast` media query isn't supported in Firefox. Firefox doesn't render background images in high contrast mode; use this latter fact to detect high contrast mode.

High contrast mode isn't needed for the preview frame, because it makes the full page shot weirdly transparent.