### PR TITLE
Extend default resource expiration time to 30 days

### DIFF
--- a/server/src/caching.js
+++ b/server/src/caching.js
@@ -1,6 +1,6 @@
 const config = require("./config").getProperties();
 
-exports.cacheTime = 60 * 60 * 24 * 1; // 1 day
+exports.cacheTime = 60 * 60 * 24 * 30; // 30 days
 
 if (!config.setCache) {
   exports.cacheTime = 0;


### PR DESCRIPTION
This is relatively safe since we use commit-hash-based cache busters on URLs.
This fixes one of the last issues from #3202