### PR TITLE
Fix #3532, remove .nsprc file now that tough-cookie has been updated

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,3 +1,0 @@
-{
-  "exceptions": ["https://nodesecurity.io/advisories/525"]
-}


### PR DESCRIPTION
As seen in [1], we had to temporarily disable nsp checks due to a
potential vulnerability in tough-cookie. The request library has been
updated to use the updated tough-cookie, and, thanks to loose version
tracking, looks like the fix percolates up to all our deps.

[1] https://circleci.com/gh/mozilla-services/screenshots/3561