### PR TITLE
Try to fix #3581, make Screenshots work with third party cookies disabled

### DIFF
--- a/addon/webextension/background/auth.js
+++ b/addon/webextension/background/auth.js
@@ -200,12 +200,19 @@ this.auth = (function() {
 
   communication.register("getAuthInfo", (sender, ownershipCheck) => {
     return registrationInfoFetched.then(() => {
+      return exports.authHeaders();
+    }).then((authHeaders) => {
       let info = registrationInfo;
       if (info.registered) {
         return login({ownershipCheck}).then((result) => {
-          return {isOwner: result && result.isOwner, deviceId: registrationInfo.deviceId};
+          return {
+            isOwner: result && result.isOwner,
+            deviceId: registrationInfo.deviceId,
+            authHeaders
+          };
         });
       }
+      info = Object.assign({authHeaders}, info);
       return info;
     });
   });

--- a/addon/webextension/sitehelper.js
+++ b/addon/webextension/sitehelper.js
@@ -6,6 +6,10 @@
 
 this.sitehelper = (function() {
 
+  // This gives us the content's copy of XMLHttpRequest, instead of the wrapped
+  // copy that this content script gets:
+  let ContentXMLHttpRequest = window.wrappedJSObject.XMLHttpRequest;
+
   catcher.registerHandler((errorObj) => {
     callBackground("reportError", errorObj);
   });
@@ -20,6 +24,32 @@ this.sitehelper = (function() {
     document.dispatchEvent(new CustomEvent(name, {detail}));
   }
 
+  /** Set the cookie, even if third-party cookies are disabled in this browser
+      (when they are disabled, login from the background page won't set cookies) */
+  function sendBackupCookieRequest(authHeaders) {
+    // See https://bugzilla.mozilla.org/show_bug.cgi?id=1295660
+    //   This bug would allow us to access window.content.XMLHttpRequest, and get
+    //   a safer (not overridable by content) version of the object.
+
+    // This is a very minimal attempt to verify that the XMLHttpRequest object we got
+    // is legitimate. It is not a good test.
+    if (Object.toString.apply(ContentXMLHttpRequest) != "function XMLHttpRequest() {\n    [native code]\n}") {
+      console.warn("Insecure copy of XMLHttpRequest");
+      return;
+    }
+    let req = new ContentXMLHttpRequest();
+    req.open("POST", "/api/set-login-cookie");
+    for (let name in authHeaders) {
+      req.setRequestHeader(name, authHeaders[name]);
+    }
+    req.send("");
+    req.onload = () => {
+      if (req.status != 200) {
+        console.warn("Attempt to set Screenshots cookie via /api/set-login-cookie failed:", req.status, req.statusText, req.responseText);
+      }
+    };
+  }
+
   document.addEventListener("delete-everything", catcher.watchFunction((event) => {
     // FIXME: reset some data in the add-on
   }, false));
@@ -27,6 +57,7 @@ this.sitehelper = (function() {
   document.addEventListener("request-login", catcher.watchFunction((event) => {
     let shotId = event.detail;
     catcher.watchPromise(callBackground("getAuthInfo", shotId || null).then((info) => {
+      sendBackupCookieRequest(info.authHeaders);
       sendCustomEvent("login-successful", {deviceId: info.deviceId, isOwner: info.isOwner});
     }));
   }));

--- a/server/src/middleware/csrf.js
+++ b/server/src/middleware/csrf.js
@@ -26,7 +26,8 @@ function isCsrfExemptPath(path) {
   return isAuthPath(path)
     || path.startsWith("/data")
     || path === "/event"
-    || path === "/error";
+    || path === "/error"
+    || path === "/api/set-login-cookie";
 }
 
 function csrfHeadersValid(req) {

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -587,6 +587,19 @@ app.post("/api/login", function(req, res) {
   });
 });
 
+app.post("/api/set-login-cookie", function(req, res) {
+  if (!req.deviceId) {
+    sendRavenMessage(req, "Attempt to set login cookie without authentication");
+    simpleResponse(res, "Not logged in", 401);
+    return;
+  }
+  sendAuthInfo(req, res, {
+    deviceId: req.deviceId,
+    accountId: req.accountId,
+    userAbTests: req.abTests
+  });
+});
+
 app.put("/data/:id/:domain", upload.single('blob'), function(req, res) {
   let slowResponse = config.testing.slowResponse;
   let failSometimes = config.testing.failSometimes;

--- a/test/server/clientlib.py
+++ b/test/server/clientlib.py
@@ -32,6 +32,7 @@ class ScreenshotsClient(object):
                 urljoin(self.backend, "/api/register"),
                 data=dict(deviceId=self.deviceId, secret=self.secret, deviceInfo=json.dumps(self.deviceInfo)))
         resp.raise_for_status()
+        return resp
 
     def delete_account(self):
         page = self.session.get(self.backend + "/leave-screenshots/").text

--- a/test/server/test_auth.py
+++ b/test/server/test_auth.py
@@ -169,6 +169,21 @@ def test_login():
         assert resp.status_code == 200
 
 
+def test_set_login_cookie():
+    sess1 = ScreenshotsClient()
+    login_resp = sess1.login()
+    headers = {'x-screenshots-auth': login_resp.json()['authHeader']}
+    assert sess1.session.cookies['user'] and sess1.session.cookies['user.sig']
+    sess2 = ScreenshotsClient()
+    # Trying to login without any authentication won't work:
+    resp = sess2.session.post(sess2.backend + "/api/set-login-cookie")
+    assert resp.status_code == 401
+    assert not sess2.session.cookies.get('user')
+    resp = sess2.session.post(sess2.backend + "/api/set-login-cookie", headers=headers)
+    assert resp.status_code == 200
+    assert sess2.session.cookies['user'] and sess2.session.cookies['user.sig']
+
+
 if __name__ == "__main__":
     test_register_without_deviceid_fails()
     test_register_without_secret_fails()
@@ -181,3 +196,4 @@ if __name__ == "__main__":
     test_login_invalid_json_deviceinfo()
     test_login_ownership_check()
     test_login()
+    test_set_login_cookie()


### PR DESCRIPTION
This adds a second attempt to login to wantsauth logins, one that runs in sitehelper.js, and tries to get the cookie set on a request that appears to come from the content page itself.

Note: this now works, but doesn't provide full protection from a screenshots.firefox.com page (that is under attack) from getting the authentication header.