### PR TITLE
Fix #3495, Fix pluralization by passing integer time diffs as numbers, not strings

### DIFF
--- a/server/src/pages/shot/time-diff.js
+++ b/server/src/pages/shot/time-diff.js
@@ -14,7 +14,7 @@ exports.TimeDiff = class TimeDiff extends React.Component {
     } else {
       timeDiff = this.dateString(this.props.date);
     }
-    return <Localized id={timeDiff.l10nID} $number={timeDiff.diff}><span title={this.dateString(this.props.date)}></span></Localized>
+    return <Localized id={timeDiff.l10nID} $number={this.state.useLocalTime ? parseInt(timeDiff.diff, 10) : timeDiff.diff}><span title={this.dateString(this.props.date)}></span></Localized>
   }
 
   componentDidMount() {


### PR DESCRIPTION
The Localized fluent-react component doesn't coerce strings to numbers,
so strings like "1" are mistakenly rendered using the default
pluralization. Bug #3495 is due to our use of the plural as the default
(for example, see the 'timeDiffMinutesAgo' l10n key).