### PR TITLE
Set cache expiration for shot images. (#3591)

### DIFF
--- a/server/src/caching.js
+++ b/server/src/caching.js
@@ -1,17 +1,23 @@
 const config = require("./config").getProperties();
 
+const aDayInSeconds = 24 * 60 * 60;
 exports.cacheTime = 60 * 60 * 24 * 30; // 30 days
 
 if (!config.setCache) {
   exports.cacheTime = 0;
 }
 
-exports.setCache = function(res, options) {
-  if (config.setCache) {
-    options = options || {};
-    let pub = options.private ? "private" : "public";
-    res.set("Cache-Control", `${pub}, max-age=${exports.cacheTime}`);
-  } else {
-    res.set("Cache-Control", "no-cache");
+function createCacheSetter(cacheLength) {
+  return function(res, options) {
+    if (config.setCache && cacheLength) {
+      options = options || {};
+      let pub = options.private ? "private" : "public";
+      res.set("Cache-Control", `${pub}, max-age=${cacheLength}`);
+    } else {
+      res.set("Cache-Control", "no-cache");
+    }
   }
-};
+}
+
+exports.setMonthlyCache = createCacheSetter(exports.cacheTime);
+exports.setDailyCache = createCacheSetter(aDayInSeconds);

--- a/server/src/caching.js
+++ b/server/src/caching.js
@@ -1,5 +1,6 @@
 const config = require("./config").getProperties();
 
+const tenMinutesInSeconds = 10 * 60;
 const aDayInSeconds = 24 * 60 * 60;
 exports.cacheTime = 60 * 60 * 24 * 30; // 30 days
 
@@ -7,12 +8,21 @@ if (!config.setCache) {
   exports.cacheTime = 0;
 }
 
-function createCacheSetter(cacheLength) {
+function createCacheSetter(maxAge, flags) {
   return function(res, options) {
-    if (config.setCache && cacheLength) {
+    if (config.setCache && maxAge) {
+      let vals = [];
       options = options || {};
+
       let pub = options.private ? "private" : "public";
-      res.set("Cache-Control", `${pub}, max-age=${cacheLength}`);
+      vals.push(pub);
+      vals.push(`max-age=${maxAge}`)
+
+      if (flags) {
+        vals = vals.concat(flags);
+      }
+
+      res.set("Cache-Control", vals.join(', '));
     } else {
       res.set("Cache-Control", "no-cache");
     }
@@ -20,4 +30,4 @@ function createCacheSetter(cacheLength) {
 }
 
 exports.setMonthlyCache = createCacheSetter(exports.cacheTime);
-exports.setDailyCache = createCacheSetter(aDayInSeconds);
+exports.setDailyCache = createCacheSetter(aDayInSeconds, `s-maxage=${tenMinutesInSeconds}`);

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -44,7 +44,7 @@ const gaActivation = require("./ga-activation");
 const genUuid = require("nodify-uuid");
 const statsd = require("./statsd");
 const { notFound } = require("./pages/not-found/server");
-const { cacheTime, setCache } = require("./caching");
+const { cacheTime, setMonthlyCache, setDailyCache } = require("./caching");
 const { captureRavenException, sendRavenMessage,
         addRavenRequestHandler, addRavenErrorHandler } = require("./ravenclient");
 const { errorResponse, simpleResponse, jsResponse } = require("./responses");
@@ -307,7 +307,7 @@ app.get("/ga-activation-hashed.js", function(req, res) {
 
 function sendGaActivation(req, res, hashPage) {
   let promise;
-  setCache(res, {private: true});
+  setMonthlyCache(res, {private: true});
   if (req.deviceId) {
     promise = hashUserId(req.deviceId).then((uuid) => {
       return uuid.toString();
@@ -326,7 +326,7 @@ function sendGaActivation(req, res, hashPage) {
 const parentHelperJs = readFileSync(path.join(__dirname, "/static/js/parent-helper.js"), {encoding: "UTF-8"});
 
 app.get("/parent-helper.js", function(req, res) {
-  setCache(res);
+  setMonthlyCache(res);
   let postMessageOrigin = `${req.protocol}://${req.config.contentOrigin}`;
   let script = `${parentHelperJs}\nvar CONTENT_HOSTING_ORIGIN = "${postMessageOrigin}";`
   jsResponse(res, script);
@@ -335,7 +335,7 @@ app.get("/parent-helper.js", function(req, res) {
 const ravenClientJs = readFileSync(require.resolve("raven-js/dist/raven.min"), {encoding: "UTF-8"});
 
 app.get("/install-raven.js", function(req, res) {
-  setCache(res);
+  setMonthlyCache(res);
   if (!req.config.sentryPublicDSN) {
     jsResponse(res, "");
     return;
@@ -855,6 +855,7 @@ app.get("/images/:imageid", function(req, res) {
           res.header("Content-Disposition", contentDisposition(download));
         }
       }
+      setDailyCache(res);
       res.status(200);
       res.send(obj.data);
     }


### PR DESCRIPTION
Without data, I'm taking a guess that shot access/share has a long tail, so the cache expiration is set to a day.

Fix #3591 