### PR TITLE
Fix #3314, Avoid infinite selection loop by checking minimum size

### DIFF
--- a/addon/webextension/selector/uicontrol.js
+++ b/addon/webextension/selector/uicontrol.js
@@ -461,6 +461,11 @@ this.uicontrol = (function() {
           rect = lastRect;
           break;
         }
+        if (rect.width < MIN_DETECT_WIDTH || rect.height < MIN_DETECT_HEIGHT) {
+          // Avoid infinite loop for elements with zero or nearly zero height,
+          // like non-clearfixed float parents with or without borders.
+          break;
+        }
         if (rect.width > MAX_DETECT_WIDTH || rect.height > MAX_DETECT_HEIGHT) {
           // Then the last rectangle is better
           rect = lastRect;


### PR DESCRIPTION
Source code files on dxr.mozilla.org are rendered as floats inside a
non-clearfixed parent element, which has a calculated height of 0. This
condition isn't handled in the current loop logic, leading to an infinite
while loop that locks up the UI.