### PR TITLE
Update circle.yml change baseline conf to master

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -43,7 +43,7 @@ test:
         ip="$(ip -f inet -o addr show docker0 | awk '{print $4}' | cut -d '/' -f 1)" &&
         docker run -t owasp/zap2docker-weekly zap-baseline.py \
             -t http://${ip}:10080 \
-            -u https://raw.githubusercontent.com/mozilla-services/screenshots/zap-baseline-2/.zap-baseline.conf;
+            -u https://raw.githubusercontent.com/mozilla-services/screenshots/master/.zap-baseline.conf;
         if [ $? -ne 1 ]; then exit 0; else exit 1; fi;
         )
 


### PR DESCRIPTION
The zap baseline 2 branch was deleted so https://raw.githubusercontent.com/mozilla-services/screenshots/zap-baseline-2/.zap-baseline.conf 404s.

refs: https://github.com/mozilla-services/screenshots/pull/3321

r? @6a68 