### PR TITLE
[do not merge] Put save/download buttons in the shoulder, not near the image

### DIFF
--- a/locales/en-US/webextension.properties
+++ b/locales/en-US/webextension.properties
@@ -6,6 +6,7 @@ contextMenuLabel = Take a Screenshot
 myShotsLink = My Shots
 screenshotInstructions = Drag or click on the page to select a region. Press ESC to cancel.
 saveScreenshotSelectedArea = Save
+saveScreenshotSelectedAreaToCloud = Save to Cloud
 saveScreenshotVisibleArea = Save visible
 saveScreenshotFullPage = Save full page
 cancelScreenshot = Cancel

--- a/static/css/inline-selection.scss
+++ b/static/css/inline-selection.scss
@@ -224,23 +224,14 @@ $very-light-grey: #ededed;
 
 .highlight-buttons {
   @include flex-container(row, center, center);
-  bottom: -55px;
-  position: absolute;
+  z-index: $overlay-z-index + 1;
+  position: fixed;
+  top: 10px;
   html[dir="rtl"] & {
     left: 5px;
   }
   html[dir="ltr"] & {
     right: 5px;
-  }
-  z-index: 6;
-
-  .bottom-selection & {
-    bottom: 5px;
-  }
-
-  .left-selection & {
-    right: auto;
-    left: 5px;
   }
 }
 
@@ -493,6 +484,26 @@ $very-light-grey: #ededed;
 
   .visible {
     background-image: url("MOZ_EXTENSION/icons/menu-visible.svg");
+  }
+
+  .cancel {
+    background-image: url("MOZ_EXTENSION/icons/cancel.svg");
+    background-size: 35px 35px;
+    background-position: center 8px;
+  }
+
+  .download {
+    background-image: url("MOZ_EXTENSION/icons/download.svg");
+    background-size: 35px 35px;
+    background-position: center 10px;
+  }
+
+  .save {
+    background-image: url("MOZ_EXTENSION/icons/cloud.svg");
+    background-size: 35px 35px;
+    background-position: center 10px;
+    background-color: #009ec0;
+    &:hover { background-color: #00819c; }
   }
 }
 


### PR DESCRIPTION
(Code works, but I want to wait to merge until this gets UX feedback.)

@johngruen @youwenliang @ianb mind taking a look?

When looking at issues related to selection button positioning, it
occurred to me that the UI would be more consistent if we always kept
the controls positioned at the top corner of the screen. This commit
moves the selection buttons (cancel, save, download) to the top-right
corner of the overlay, and adjusts their style to match the
pre-selection shoulder buttons (save full page, save visible, my shots).

The shoulder button fixed positioning is a little janky if the page is
fast-scrolled when there's a selection. `Position: sticky` would be ideal
here, as the jank is caused by async scrolling, but `sticky` doesn't work
inside a positioned iframe, same problem as trying to use `position:
fixed` inside an absolutely positioned iframe :-\

It does seem unlikely that a user would fast-scroll a page while
adjusting the screenshot selection's dimensions, so hopefully this jank
won't be noticeable to everyday users.

Still todo: need to tidy up CSS. Also, the label text looks a little small.

-----

Screenshots of the new buttons in the creation flow:

<img width="1037" alt="screen shot 2017-10-17 at 5 05 29 pm" src="https://user-images.githubusercontent.com/96396/31695155-bcd94a84-b35d-11e7-9ed8-27da8e45bddb.png">
<img width="1037" alt="screen shot 2017-10-17 at 5 05 39 pm" src="https://user-images.githubusercontent.com/96396/31695156-bcfb08fe-b35d-11e7-87f4-226dfadad6e1.png">

-----

Close-up screenshots of the button strip and hover states:

<img width="336" alt="screen shot 2017-10-17 at 5 06 05 pm" src="https://user-images.githubusercontent.com/96396/31695157-bd1d7e20-b35d-11e7-983b-26676a81c640.png">
<img width="344" alt="screen shot 2017-10-17 at 5 06 39 pm" src="https://user-images.githubusercontent.com/96396/31695161-bda33042-b35d-11e7-957a-ad619530fabc.png">
<img width="338" alt="screen shot 2017-10-17 at 5 06 28 pm" src="https://user-images.githubusercontent.com/96396/31695159-bd5d692c-b35d-11e7-9413-af7489206f04.png">
<img width="345" alt="screen shot 2017-10-17 at 5 06 34 pm" src="https://user-images.githubusercontent.com/96396/31695160-bd80f09a-b35d-11e7-849b-d29be75be3bb.png">

