### PR TITLE
Download only mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /Profile
 .DS_Store
+*.swp
+*.swo
 screenshots.xpi
 *.pyc
 dist

--- a/addon/webextension/background/main.js
+++ b/addon/webextension/background/main.js
@@ -236,12 +236,16 @@ this.main = (function() {
       }
     });
     browser.downloads.onChanged.addListener(onChangedCallback)
-    return browser.downloads.download({
-      url,
-      filename: info.filename
-    }).then((id) => {
-      downloadId = id;
-    });
+    return browser.windows.getLastFocused().then(windowInfo => {
+      return windowInfo.incognito;
+    }).then((incognito) => {
+      return browser.downloads.download({
+        url,
+        incognito,
+        filename: info.filename
+      }).then((id) => {
+        downloadId = id;
+      });
   });
 
   communication.register("closeSelector", (sender) => {

--- a/addon/webextension/background/main.js
+++ b/addon/webextension/background/main.js
@@ -96,12 +96,6 @@ this.main = (function() {
 
   // This is called by startBackground.js, directly in response to clicks on the Photon page action
   exports.onClicked = catcher.watchFunction((tab) => {
-    if (tab.incognito) {
-      senderror.showError({
-        popupMessage: "PRIVATE_WINDOW"
-      });
-      return;
-    }
     if (shouldOpenMyShots(tab.url)) {
       if (!hasSeenOnboarding) {
         catcher.watchPromise(analytics.refreshTelemetryPref().then(() => {
@@ -139,12 +133,6 @@ this.main = (function() {
   exports.onClickedContextMenu = catcher.watchFunction((info, tab) => {
     if (!tab) {
       // Not in a page/tab context, ignore
-      return;
-    }
-    if (tab.incognito) {
-      senderror.showError({
-        popupMessage: "PRIVATE_WINDOW"
-      });
       return;
     }
     if (!urlEnabled(tab.url)) {
@@ -246,6 +234,7 @@ this.main = (function() {
       }).then((id) => {
         downloadId = id;
       });
+    });
   });
 
   communication.register("closeSelector", (sender) => {

--- a/addon/webextension/background/selectorLoader.js
+++ b/addon/webextension/background/selectorLoader.js
@@ -84,7 +84,10 @@ this.selectorLoader = (function() {
   function incognitoCheck(tabId) {
     return browser.tabs.get(tabId).then(tab => {
       return browser.tabs.executeScript(tabId, {
-        code: `window.incognito = ${tab.incognito};`,
+        // Note: `window` here refers to a global accessible to content
+        // scripts, but not the scripts in the underlying page. For more
+        // details, see https://mdn.io/WebExtensions/Content_scripts#Content_script_environment
+        code: `window.downloadOnly = ${tab.incognito}`,
         runAt: "document_start"
       });
     });

--- a/addon/webextension/background/selectorLoader.js
+++ b/addon/webextension/background/selectorLoader.js
@@ -68,9 +68,13 @@ this.selectorLoader = (function() {
     loadingTabs.add(tabId);
     let promise = incognitoCheck(tabId);
     if (hasSeenOnboarding) {
-      promise = promise.then(executeModules(tabId, standardScripts.concat(selectorScripts)));
+      promise = promise.then(() => {
+        return executeModules(tabId, standardScripts.concat(selectorScripts));
+      });
     } else {
-      promise = promise.then(executeModules(tabId, standardScripts.concat(onboardingScripts).concat(selectorScripts)));
+      promise = promise.then(() => {
+        return executeModules(tabId, standardScripts.concat(onboardingScripts).concat(selectorScripts));
+      });
     }
     return promise.then((result) => {
       loadingTabs.delete(tabId);

--- a/addon/webextension/selector/ui.js
+++ b/addon/webextension/selector/ui.js
@@ -92,27 +92,17 @@ this.ui = (function() { // eslint-disable-line no-unused-vars
   }
 
   function isDownloadOnly() {
-    return window.incognito;
+    return window.downloadOnly;
   }
 
   function renderDownloadNotice() {
     let notice = makeEl("div", "download-only");
-    notice.textContent = browser.i18n.getMessage("downloadOnlyNotice");
-    let questionMark = makeEl("span", "circle");
-    questionMark.textContent = "?";
-    notice.appendChild(questionMark);
-
-    let tooltip = makeEl("div", "download-only-details");
-    let details = makeEl("p");
-    details.textContent = browser.i18n.getMessage("downloadOnlyDetails");
-    let detailsList = makeEl("ul");
-    let detailsPrivate = makeEl("li");
-    detailsPrivate.textContent = browser.i18n.getMessage("downloadOnlyDetailsPrivate");
-
-    detailsList.appendChild(detailsPrivate);
-    details.appendChild(detailsList);
-    tooltip.appendChild(details);
-    notice.appendChild(tooltip);
+    notice.innerHTML = `
+      <span data-l10n-id="downloadOnlyNotice"></span><span class="circle">?</span>
+      <div class="download-only-details">
+        <p data-l10n-id="downloadOnlyDetails">
+          <ul><li data-l10n-id="downloadOnlyDetailsPrivate">`;
+    localizeText(notice);
     return notice;
   }
 

--- a/locales/en-US/webextension.properties
+++ b/locales/en-US/webextension.properties
@@ -10,6 +10,14 @@ saveScreenshotVisibleArea = Save visible
 saveScreenshotFullPage = Save full page
 cancelScreenshot = Cancel
 downloadScreenshot = Download
+downloadOnlyNotice = You are currently in Download-Only mode.
+# The downloadOnlyDetails string introduces a list of items. The keys
+# downloadOnlyDetailsPrivate, downloadOnlyDetailsThirdParty, and
+# downloadOnlyDetailsNeverRemember are list items in that list.
+downloadOnlyDetails = Firefox Screenshots automatically changes to Download-Only mode in these situations:
+downloadOnlyDetailsPrivate = In a Private Browsing window.
+downloadOnlyDetailsThirdParty = Third-party cookies are disabled.
+downloadOnlyDetailsNeverRemember = “Never remember history” is enabled.
 notificationLinkCopiedTitle = Link Copied
 # The string "{meta_key}-V" should be translated to the region-specific
 # shorthand for the Paste keyboard shortcut. {meta_key} is a placeholder for the

--- a/static/css/inline-selection.scss
+++ b/static/css/inline-selection.scss
@@ -201,7 +201,7 @@ $very-light-grey: #ededed;
 
   padding: 12px 25px;
   border-radius: 100px;
-  background: #808080;
+  background: #737373;
   font-family: -apple-system, BlinkMacSystemFont, "segoe ui", "helvetica neue", helvetica, ubuntu, roboto, noto, arial, sans-serif;
   font-weight: bold;
   color: #fff;
@@ -228,7 +228,7 @@ $very-light-grey: #ededed;
   position: absolute;
   bottom: 72px;
   right: -50px;
-  background: #737373;
+  background: #fff;
   border: 1px solid #9d9d9e;
   border-radius: 3px;
   padding: 0 20px;

--- a/static/css/inline-selection.scss
+++ b/static/css/inline-selection.scss
@@ -190,6 +190,74 @@ $very-light-grey: #ededed;
   }
 }
 
+.download-only {
+  position:absolute;
+  z-index: $overlay-z-index + 1;
+  bottom: 10px;
+
+  /* horizontal centering */
+  left: 50%;
+  transform: translate(-50%, 0);
+
+  padding: 12px 25px;
+  border-radius: 100px;
+  background: #808080;
+  font-family: -apple-system, BlinkMacSystemFont, "segoe ui", "helvetica neue", helvetica, ubuntu, roboto, noto, arial, sans-serif;
+  font-weight: bold;
+  color: #fff;
+  font-size: 18px;
+  line-height: 26px;
+  white-space: nowrap;
+  user-select: none;
+}
+
+.circle {
+  display: inline-table;
+  border: 1px solid #f9f9fa;
+  border-radius: 50%;
+  padding: 1px 9px;
+  margin-left: 10px;
+  margin-right: -10px;
+  cursor: default;
+}
+
+.download-only-details {
+  z-index: $overlay-z-index + 1;
+  display: none;
+  width: 400px;
+  position: absolute;
+  bottom: 72px;
+  right: -50px;
+  background: #737373;
+  border: 1px solid #9d9d9e;
+  border-radius: 3px;
+  padding: 0 20px;
+  font-family: -apple-system, BlinkMacSystemFont, "segoe ui", "helvetica neue", helvetica, ubuntu, roboto, noto, arial, sans-serif;
+  font-weight: normal;
+  font-size: 16px;
+  line-height: 24px;
+  white-space: normal;
+  color: #000;
+  cursor: default;
+
+  .download-only:hover & {
+    display: block;
+  }
+
+  /* down-arrow for the tooltip */
+  &::after {
+    content: "";
+    position: absolute;
+    height: 0;
+    width: 0;
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+    border-top: 10px solid #f9f9fa;
+    top: 100%;
+    left: 80%;
+  }
+}
+
 .preview-overlay {
   align-items: center;
   background-color: $modal-color;
@@ -291,6 +359,12 @@ $very-light-grey: #ededed;
   display: block;
   margin: 5px;
   width: 40px;
+
+  &.download-only-button {
+    width: auto;
+    background-position: 7px;
+    padding-left: 32px;
+  }
 }
 
 .pixel-dimensions {

--- a/static/css/inline-selection.scss
+++ b/static/css/inline-selection.scss
@@ -199,13 +199,13 @@ $very-light-grey: #ededed;
   left: 50%;
   transform: translate(-50%, 0);
 
-  padding: 12px 25px;
+  padding: 10px 15px;
   border-radius: 100px;
   background: #737373;
   font-family: -apple-system, BlinkMacSystemFont, "segoe ui", "helvetica neue", helvetica, ubuntu, roboto, noto, arial, sans-serif;
   font-weight: bold;
   color: #fff;
-  font-size: 18px;
+  font-size: 14px;
   line-height: 26px;
   white-space: nowrap;
   user-select: none;


### PR DESCRIPTION
@youwenliang @johngruen Mind taking a look?

Updated, now showing the download-only mode warning in the full-page preview; see screenshot below.

~~Nearly done, but just realized I've got to add the warning to the full-page preview frame. Need to do a round of todo cleanups, too.~~

Screenshots of the private browsing mode screens:


<img width="1015" alt="screen shot 2017-10-18 at 3 05 16 pm" src="https://user-images.githubusercontent.com/96396/31745111-7a85fff6-b416-11e7-9909-307b561eedb3.png">
<img width="1015" alt="screen shot 2017-10-18 at 3 05 14 pm" src="https://user-images.githubusercontent.com/96396/31745110-7a642098-b416-11e7-9ae7-633c2bf3f429.png">
<img width="1325" alt="screen shot 2017-10-22 at 5 03 50 pm" src="https://user-images.githubusercontent.com/96396/31867864-5303adf6-b74b-11e7-896d-eedaca05da8d.png">

