### PR TITLE
disable full-page truncation warning if download-only warning will be shown

### DIFF
--- a/addon/webextension/selector/ui.js
+++ b/addon/webextension/selector/ui.js
@@ -790,7 +790,7 @@ this.ui = (function() { // eslint-disable-line no-unused-vars
       let img = makeEl("IMG");
       img.src = dataUrl;
       iframe.document().querySelector(".preview-image").appendChild(img);
-      if (showCropWarning) {
+      if (showCropWarning && !(isDownloadOnly())) {
         let imageCroppedEl = makeEl("DIV");
         imageCroppedEl.id = "imageCroppedWarning";
         imageCroppedEl.textContent = browser.i18n.getMessage("imageCroppedWarning", buildSettings.maxImageHeight);


### PR DESCRIPTION
Not much else to add. Testing: open a private browsing window, scroll an infinite scroll page till it's taller than 5k pixels, click the full page button, check the notice shown at the bottom of the screen is just the download-only notice