### PR TITLE
Fix #2218, add Telemetry scalars to track shot creation per session

### DIFF
--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -229,15 +229,9 @@ function handleMessage(msg, sender, sendReply) {
     let historyEnabled = getBoolPref(HISTORY_ENABLED_PREF);
     sendReply({type: "success", value: historyEnabled});
   } else if (msg.funcName === "incrementDownloadCount") {
-    let telemetryEnabled = getBoolPref(TELEMETRY_ENABLED_PREF);
-    if (telemetryEnabled) {
-      Services.telemetry.scalarAdd('screenshots.download', 1);
-    }
+    Services.telemetry.scalarAdd('screenshots.download', 1);
   } else if (msg.funcName === "incrementUploadCount") {
-    let telemetryEnabled = getBoolPref(TELEMETRY_ENABLED_PREF);
-    if (telemetryEnabled) {
-      Services.telemetry.scalarAdd('screenshots.upload', 1);
-    }
+    Services.telemetry.scalarAdd('screenshots.upload', 1);
   }
 }
 

--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -228,6 +228,16 @@ function handleMessage(msg, sender, sendReply) {
   } else if (msg.funcName === "getHistoryPref") {
     let historyEnabled = getBoolPref(HISTORY_ENABLED_PREF);
     sendReply({type: "success", value: historyEnabled});
+  } else if (msg.funcName === "incrementDownloadCount") {
+    let telemetryEnabled = getBoolPref(TELEMETRY_ENABLED_PREF);
+    if (telemetryEnabled) {
+      Services.telemetry.scalarAdd('screenshots.download', 1);
+    }
+  } else if (msg.funcName === "incrementUploadCount") {
+    let telemetryEnabled = getBoolPref(TELEMETRY_ENABLED_PREF);
+    if (telemetryEnabled) {
+      Services.telemetry.scalarAdd('screenshots.upload', 1);
+    }
   }
 }
 

--- a/addon/webextension/background/main.js
+++ b/addon/webextension/background/main.js
@@ -224,6 +224,7 @@ this.main = (function() {
       }
     });
     browser.downloads.onChanged.addListener(onChangedCallback)
+    catcher.watchPromise(communication.sendToBootstrap("incrementDownloadCount"));
     return browser.windows.getLastFocused().then(windowInfo => {
       return windowInfo.incognito;
     }).then((incognito) => {

--- a/addon/webextension/background/takeshot.js
+++ b/addon/webextension/background/takeshot.js
@@ -72,6 +72,7 @@ this.takeshot = (function() {
         }
       );
     }).then(() => {
+      catcher.watchPromise(communication.sendToBootstrap('incrementUploadCount'));
       return shot.viewUrl;
     }).catch((error) => {
       browser.tabs.remove(openedTab.id);


### PR DESCRIPTION
For related, Gecko-only changes to the telemetry Scalars.yaml file, see
https://bugzilla.mozilla.org/show_bug.cgi?id=1412411