### PR TITLE
Generate, upload, and display thumbnail of shots.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ build/%.html: %.html
 	cp $< $@
 
 .PHONY: addon
-addon: npm set_backend set_sentry addon/webextension/manifest.json addon/install.rdf addon_locales addon/webextension/build/shot.js addon/webextension/build/inlineSelectionCss.js addon/webextension/build/raven.js addon/webextension/build/onboardingCss.js addon/webextension/build/onboardingHtml.js addon/webextension/build/buildSettings.js
+addon: npm set_backend set_sentry addon/webextension/manifest.json addon/install.rdf addon_locales addon/webextension/build/shot.js addon/webextension/build/thumbnailGenerator.js addon/webextension/build/inlineSelectionCss.js addon/webextension/build/raven.js addon/webextension/build/onboardingCss.js addon/webextension/build/onboardingHtml.js addon/webextension/build/buildSettings.js
 
 $(VENV): bin/require.pip
 	virtualenv -p python2.7 $(VENV)
@@ -134,6 +134,10 @@ addon/webextension/manifest.json: addon/webextension/manifest.json.template buil
 addon/webextension/build/shot.js: shared/shot.js
 	@mkdir -p $(@D)
 	./bin/build-scripts/modularize shot $< > $@
+
+addon/webextension/build/thumbnailGenerator.js: shared/thumbnailGenerator.js
+	@mkdir -p $(@D)
+	./bin/build-scripts/modularize thumbnailGenerator $< > $@
 
 addon/webextension/build/inlineSelectionCss.js: build/server/static/css/inline-selection.css
 	@mkdir -p $(@D)

--- a/addon/webextension/background/startBackground.js
+++ b/addon/webextension/background/startBackground.js
@@ -22,6 +22,7 @@ this.startBackground = (function() {
     "background/senderror.js",
     "build/raven.js",
     "build/shot.js",
+    "build/thumbnailGenerator.js",
     "background/analytics.js",
     "background/deviceInfo.js",
     "background/takeshot.js",

--- a/addon/webextension/background/takeshot.js
+++ b/addon/webextension/background/takeshot.js
@@ -1,4 +1,4 @@
-/* globals communication, shot, main, auth, catcher, analytics, buildSettings, blobConverters */
+/* globals communication, shot, main, auth, catcher, analytics, buildSettings, blobConverters, thumbnailGenerator */
 
 "use strict";
 
@@ -13,6 +13,7 @@ this.takeshot = (function() {
     shot.favicon = sender.tab.favIconUrl;
     let capturePromise = Promise.resolve();
     let openedTab;
+    let thumbnailBlob;
     if (!shot.clipNames().length) {
       // canvas.drawWindow isn't available, so we fall back to captureVisibleTab
       capturePromise = screenshotPage(selectedPos, scroll).then((dataUrl) => {
@@ -33,8 +34,9 @@ this.takeshot = (function() {
     }
     let convertBlobPromise = Promise.resolve();
     if (buildSettings.uploadBinary && !imageBlob) {
-      imageBlob = blobConverters.dataUrlToBlob(shot.getClip(shot.clipNames()[0]).image.url);
-      shot.getClip(shot.clipNames()[0]).image.url = "";
+      let clipImage = shot.getClip(shot.clipNames()[0]).image;
+      imageBlob = blobConverters.dataUrlToBlob(clipImage.url);
+      clipImage.url = "";
     } else if (!buildSettings.uploadBinary && imageBlob) {
       convertBlobPromise = blobConverters.blobToDataUrl(imageBlob).then((dataUrl) => {
         shot.getClip(shot.clipNames()[0]).image.url = dataUrl;
@@ -54,11 +56,23 @@ this.takeshot = (function() {
     return catcher.watchPromise(capturePromise.then(() => {
       return convertBlobPromise;
     }).then(() => {
+      if (buildSettings.uploadBinary) {
+        let blobToUrlPromise = blobConverters.blobToDataUrl(imageBlob);
+        return thumbnailGenerator.createThumbnailBlobFromPromise(shot, blobToUrlPromise);
+      }
+      return thumbnailGenerator.createThumbnailUrl(shot);
+    }).then((thumbnailImage) => {
+      if (buildSettings.uploadBinary) {
+        thumbnailBlob = thumbnailImage;
+      } else {
+        shot.thumbnail = thumbnailImage;
+      }
+    }).then(() => {
       return browser.tabs.create({url: shot.creatingUrl})
     }).then((tab) => {
       openedTab = tab;
       sendEvent('internal', 'open-shot-tab');
-      return uploadShot(shot, imageBlob);
+      return uploadShot(shot, imageBlob, thumbnailBlob);
     }).then(() => {
       return browser.tabs.update(openedTab.id, {url: shot.viewUrl}).then(
         null,
@@ -131,29 +145,43 @@ this.takeshot = (function() {
   }
 
   /** Creates a multipart TypedArray, given {name: value} fields
-      and {name: blob} files
+      and a files array in the format of
+      [{fieldName: "NAME", filename: "NAME.png", blob: fileBlob}, {...}, ...]
 
       Returns {body, "content-type"}
       */
-  function createMultipart(fields, fileField, fileFilename, blob) {
+  function createMultipart(fields, files) {
     let boundary = "---------------------------ScreenshotBoundary" + Date.now();
-    return blobConverters.blobToArray(blob).then((blobAsBuffer) => {
-      let body = [];
-      for (let name in fields) {
-        body.push("--" + boundary);
-        body.push(`Content-Disposition: form-data; name="${name}"`);
-        body.push("");
-        body.push(fields[name]);
-      }
+    let body = [];
+    for (let name in fields) {
       body.push("--" + boundary);
-      body.push(`Content-Disposition: form-data; name="${fileField}"; filename="${fileFilename}"`);
-      body.push(`Content-Type: ${blob.type}`);
+      body.push(`Content-Disposition: form-data; name="${name}"`);
       body.push("");
-      body.push("");
-      body = body.join("\r\n");
-      let enc = new TextEncoder("utf-8");
-      body = enc.encode(body);
-      body = concatBuffers(body.buffer, blobAsBuffer);
+      body.push(fields[name]);
+    }
+    body.push("");
+    body = body.join("\r\n");
+    let enc = new TextEncoder("utf-8");
+    body = enc.encode(body).buffer;
+
+    let blobToArrayPromises = files.map(f => {
+      return blobConverters.blobToArray(f.blob);
+    });
+
+    return Promise.all(blobToArrayPromises).then(buffers => {
+      for (let i = 0; i < buffers.length; i++) {
+        let filePart = [];
+        filePart.push("--" + boundary);
+        filePart.push(`Content-Disposition: form-data; name="${files[i].fieldName}"; filename="${files[i].filename}"`);
+        filePart.push(`Content-Type: ${files[i].blob.type}`);
+        filePart.push("");
+        filePart.push("");
+        filePart = filePart.join("\r\n");
+        filePart = concatBuffers(enc.encode(filePart).buffer, buffers[i]);
+        body = concatBuffers(body, filePart);
+        body = concatBuffers(body, enc.encode("\r\n").buffer);
+      }
+
       let tail = `\r\n--${boundary}--`;
       tail = enc.encode(tail);
       body = concatBuffers(body, tail.buffer);
@@ -164,14 +192,18 @@ this.takeshot = (function() {
     });
   }
 
-  function uploadShot(shot, blob) {
+  function uploadShot(shot, blob, thumbnail) {
     let headers;
     return auth.authHeaders().then((_headers) => {
       headers = _headers;
       if (blob) {
+        let files = [ {fieldName: "blob", filename: "screenshot.png", blob} ];
+        if (thumbnail) {
+          files.push({fieldName: "thumbnail", filename: "thumbnail.png", blob: thumbnail});
+        }
         return createMultipart(
           {shot: JSON.stringify(shot.asJson())},
-          "blob", "screenshot.png", blob
+          files
         );
       }
       return {

--- a/docs/testing-the-api.md
+++ b/docs/testing-the-api.md
@@ -82,7 +82,7 @@ Authenticated.  Creates or updates a shot.  Takes a JSON body.  Looks like:
     "width": 1127,
     "height": 2086
   },
-  "fullScreenThumbnail": "data:...",
+  "thumbnail": "data:...",
   "clips": {
     "cplocgk9m1nc": {
       "createdDate": 1468983771992,

--- a/server/src/pages/shotindex/view.js
+++ b/server/src/pages/shotindex/view.js
@@ -282,12 +282,12 @@ class Card extends React.Component {
       // Some corrupted shot, we'll have to ignore it
       return null;
     }
-    if (clip && clip.image && clip.image.url) {
+    if (shot.thumbnail) {
+      imageUrl = shot.thumbnail;
+    } else if (clip && clip.image && clip.image.url) {
       imageUrl = clip.image.url;
     } else if (shot.images.length) {
       imageUrl = shot.images[0].url;
-    } else if (shot.fullScreenThumbnail) {
-      imageUrl = shot.fullScreenThumbnail;
     } else {
       imageUrl = defaultImageUrl;
     }

--- a/server/src/servershot.js
+++ b/server/src/servershot.js
@@ -756,19 +756,18 @@ ClipRewrites = class ClipRewrites {
       }
     }
     this.toInsertThumbnail = null;
-    this.oldFullScreenThumbnail = this.shot.fullScreenThumbnail;
+    this.oldThumbnail = this.shot.thumbnail;
     if (!validUrl.isWebUri(this.shot.url)) {
       this.shot.fullUrl = "";
       this.shot.origin = "";
     }
-    let url = this.shot.fullScreenThumbnail;
-    let match = (/^data:([^;]*);base64,/).exec(url);
-    if (match) {
-      let imageData = url.substr(match[0].length);
+    const pngDataUrlMediaType = "data:image/png;base64,"
+    if (this.shot.thumbnail && this.shot.thumbnail.startsWith(pngDataUrlMediaType)) {
+      let imageData = this.shot.thumbnail.substr(pngDataUrlMediaType.length);
       imageData = new Buffer(imageData, 'base64');
-      let imageId = uuid.v4();
+      let imageId = `${uuid.v4()}.png`;
       this.toInsertThumbnail = {
-        contentType: match[1],
+        contentType: "image/png",
         binary: imageData,
         uuid: imageId,
         url: linker.imageLinkWithHost(imageId)
@@ -783,7 +782,7 @@ ClipRewrites = class ClipRewrites {
       clip.image.url = url;
     }
     if (this.toInsertThumbnail !== null) {
-      this.shot.fullScreenThumbnail = this.toInsertThumbnail.url;
+      this.shot.thumbnail = this.toInsertThumbnail.url;
     }
   }
 
@@ -793,7 +792,7 @@ ClipRewrites = class ClipRewrites {
       let clip = this.shot.getClip(clipId);
       clip.setUrlFromBinary(data.binary);
     }
-    this.shot.fullScreenThumbnail = this.oldFullScreenThumbnail;
+    this.shot.thumbnail = this.oldThumbnail;
   }
 
   clear() {
@@ -876,7 +875,7 @@ ClipRewrites = class ClipRewrites {
         // Use the thumbnail uuid as the clipid. This allows figuring out which
         // images are thumbnails, too.
         [this.toInsertThumbnail.uuid, this.shot.id, this.toInsertThumbnail.uuid,
-        this.toInsertThumbnail.url, this.toInsertThumbnail.contentType, this.toInsertThumbnail.binary.data.length]);
+        this.toInsertThumbnail.url, this.toInsertThumbnail.contentType, this.toInsertThumbnail.binary.length]);
     }).then(() => {
       this.committed = true;
     });

--- a/shared/shot.js
+++ b/shared/shot.js
@@ -237,7 +237,7 @@ class AbstractShot {
     this.openGraph = attrs.openGraph || null;
     this.twitterCard = attrs.twitterCard || null;
     this.documentSize = attrs.documentSize || null;
-    this.fullScreenThumbnail = attrs.fullScreenThumbnail || null;
+    this.thumbnail = attrs.thumbnail || null;
     this.abTests = attrs.abTests || null;
     this._clips = {};
     if (attrs.clips) {
@@ -569,16 +569,16 @@ class AbstractShot {
     }
   }
 
-  get fullScreenThumbnail() {
-    return this._fullScreenThumbnail;
+  get thumbnail() {
+    return this._thumbnail;
   }
-  set fullScreenThumbnail(val) {
+  set thumbnail(val) {
     assert(typeof val == "string" || !val);
     if (val) {
       assert(isUrl(val));
-      this._fullScreenThumbnail = val;
+      this._thumbnail = val;
     } else {
-      this._fullScreenThumbnail = null;
+      this._thumbnail = null;
     }
   }
 
@@ -603,18 +603,19 @@ class AbstractShot {
 AbstractShot.prototype.REGULAR_ATTRS = (`
 origin fullUrl docTitle userTitle createdDate favicon images
 siteName openGraph twitterCard documentSize
-fullScreenThumbnail abTests
+thumbnail abTests
 `).split(/\s+/g);
 
 // Attributes that will be accepted in the constructor, but ignored/dropped
 AbstractShot.prototype.DEPRECATED_ATTRS = (`
 microdata history ogTitle createdDevice head body htmlAttrs bodyAttrs headAttrs
 readable hashtags comments showPage isPublic resources deviceId url
+fullScreenThumbnail
 `).split(/\s+/g);
 
 AbstractShot.prototype.RECALL_ATTRS = (`
 url docTitle userTitle createdDate favicon
-openGraph twitterCard images fullScreenThumbnail
+openGraph twitterCard images thumbnail
 `).split(/\s+/g);
 
 AbstractShot.prototype._OPENGRAPH_PROPERTIES = (`

--- a/shared/thumbnailGenerator.js
+++ b/shared/thumbnailGenerator.js
@@ -1,0 +1,127 @@
+// This is used in addon/webextension/background/takeshot.js and
+// server/src/pages/shot/controller.js . It is used in a browser
+// environment.
+
+// Resize down 1/2 at a time produces better image quality.
+// Not quite as good as using a third-party filter (which will be
+// slower), but good enough.
+const maxResizeScaleFactor = 0.5
+
+/**
+ * @param {dataUrl} String Data URL of the original image.
+ * @param {int} imageHeight Height in pixels of the original image.
+ * @param {int} imageWidth Width in pixels of the original image.
+ * @param {String} urlOrBlob 'blob' for a blob, otherwise data url.
+ * @returns A promise that resolves to the data URL or blob of the thumbnail image, or null.
+ */
+function createThumbnail(dataUrl, imageWidth, imageHeight, urlOrBlob) {
+  // The shot will be scaled or cropped down to 210px on x, and cropped or
+  // scaled down to a maximum of 280px on y.
+  // x: 210
+  // y: <= 280
+  const maxThumbnailWidth = 210;
+  const maxThumbnailHeight = 280;
+
+  // There's cost associated with generating, transmitting, and storing
+  // thumbnails, so we'll opt out if the image size is below a certain threshold
+  const thumbnailThresholdFactor = 1.20;
+  const thumbnailWidthThreshold = maxThumbnailWidth * thumbnailThresholdFactor;
+  const thumbnailHeightThreshold = maxThumbnailHeight * thumbnailThresholdFactor;
+
+  if (imageWidth <= thumbnailWidthThreshold &&
+      imageHeight <= thumbnailHeightThreshold) {
+    // Do not create a thumbnail.
+    return Promise.resolve(null);
+  }
+
+  const displayAspectRatio = 3 / 4;
+  let imageAspectRatio = imageWidth / imageHeight;
+  let thumbnailImageWidth, thumbnailImageHeight;
+  let scaledX, scaledY;
+
+  if (imageAspectRatio > displayAspectRatio) {
+    // "Landscape" mode
+    // Scale on y, crop on x
+    let yScaleFactor = (imageHeight > maxThumbnailHeight) ? (maxThumbnailHeight / imageHeight) : 1.0;
+    thumbnailImageHeight = scaledY = Math.round(imageHeight * yScaleFactor);
+    scaledX = Math.round(imageWidth * yScaleFactor);
+    thumbnailImageWidth = Math.min(scaledX, maxThumbnailWidth);
+  } else {
+    // "Portrait" mode
+    // Scale on x, crop on y
+    let xScaleFactor = (imageWidth > maxThumbnailWidth) ? (maxThumbnailWidth / imageWidth) : 1.0;
+    thumbnailImageWidth = scaledX = Math.round(imageWidth * xScaleFactor);
+    scaledY = Math.round(imageHeight * xScaleFactor);
+    // The CSS could widen the image, in which case we crop more off of y.
+    thumbnailImageHeight = Math.min(scaledY, maxThumbnailHeight,
+                                    maxThumbnailHeight / (maxThumbnailWidth / imageWidth));
+  }
+
+  return new Promise((resolve, reject) => {
+    let thumbnailImage = new Image();
+    let srcWidth = imageWidth;
+    let srcHeight = imageHeight;
+    let destWidth, destHeight;
+
+    thumbnailImage.onload = function() {
+      destWidth = Math.round(srcWidth * maxResizeScaleFactor);
+      destHeight = Math.round(srcHeight * maxResizeScaleFactor);
+      if (destWidth <= scaledX || destHeight <= scaledY) {
+        srcWidth = Math.round(srcWidth * (thumbnailImageWidth / scaledX));
+        srcHeight = Math.round(srcHeight * (thumbnailImageHeight / scaledY));
+        destWidth = thumbnailImageWidth;
+        destHeight = thumbnailImageHeight;
+      }
+
+      const thumbnailCanvas = document.createElement('canvas');
+      thumbnailCanvas.width = destWidth;
+      thumbnailCanvas.height = destHeight;
+      const ctx = thumbnailCanvas.getContext("2d");
+      ctx.imageSmoothingEnabled = false;
+
+      ctx.drawImage(
+        thumbnailImage,
+        0, 0, srcWidth, srcHeight,
+        0, 0, destWidth, destHeight);
+
+      if (thumbnailCanvas.width <= thumbnailImageWidth ||
+        thumbnailCanvas.height <= thumbnailImageHeight) {
+        if (urlOrBlob === "blob") {
+          thumbnailCanvas.toBlob((blob) => {
+            resolve(blob);
+          });
+        } else {
+          resolve(thumbnailCanvas.toDataURL("image/png"))
+        }
+        return;
+      }
+
+      srcWidth = destWidth;
+      srcHeight = destHeight;
+      thumbnailImage.src = thumbnailCanvas.toDataURL();
+    }
+    thumbnailImage.src = dataUrl;
+  });
+}
+
+function createThumbnailUrl(shot) {
+  const image = shot.getClip(shot.clipNames()[0]).image;
+  if (!image.url) {
+    return Promise.resolve(null);
+  }
+  return createThumbnail(
+    image.url, image.dimensions.x, image.dimensions.y, "dataurl");
+}
+
+function createThumbnailBlobFromPromise(shot, blobToUrlPromise) {
+  return blobToUrlPromise.then(dataUrl => {
+    const image = shot.getClip(shot.clipNames()[0]).image;
+    return createThumbnail(
+      dataUrl, image.dimensions.x, image.dimensions.y, "blob");
+  });
+}
+
+if (typeof exports != "undefined") {
+  exports.createThumbnailUrl = createThumbnailUrl;
+  exports.createThumbnailBlobFromPromise = createThumbnailBlobFromPromise;
+}


### PR DESCRIPTION
- The thumbnails are generated on the browser.
- The thumbnails are scaled and cropped in the same fashion as how My Shots display shots as thumbnails currently; they are not simply scaled down copies of the shot image.
- The thumbnails are always PNGs.
- This patch piggyback on some existing thumbnail related code (that did not seem to be in use?).  That code inserts the thumbnails into the `images` table and allows the thumbnails to be managed identically to the shot images.
- My Shot will fall back to using the full size shot image if a thumbnail isn't available.

Fix #3282 