### PR TITLE
Bug 366192 [bugzilla.mozilla.org] - Fixed http/https regex checks.

### DIFF
--- a/shared/shot.js
+++ b/shared/shot.js
@@ -389,7 +389,7 @@ class AbstractShot {
     if (!this.url) {
       return null;
     }
-    if (this.url.search(/^https?/i) != -1) {
+    if (/^https?:\/\//i.test(this.url)) {
       let txt = this.url;
       txt = txt.replace(/^[a-z]{1,4000}:\/\//i, "");
       txt = txt.replace(/\/.{0,4000}/, "");


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=366192