### PR TITLE
Remove extra preselection frame unhide() 

### DIFF
--- a/addon/webextension/selector/ui.js
+++ b/addon/webextension/selector/ui.js
@@ -310,7 +310,6 @@ this.ui = (function() { // eslint-disable-line no-unused-vars
             resolve();
           }), {once: true});
           document.body.appendChild(this.element);
-          this.unhide();
         } else {
           resolve();
         }


### PR DESCRIPTION
The `unhide()` being deleted was called before the iframe's loaded, which is causing #3692.  But because the `usePreselection` call at https://github.com/mozilla-services/screenshots/blob/master/addon/webextension/selector/uicontrol.js#L410 triggers an `unhide()`, this `unhide` call is unnecessary.


Fix #3692 