### PR TITLE
Properly set the Photon page action's title and icon.

### DIFF
--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -277,10 +277,10 @@ function initPhotonPageAction(api, webExtension) {
       switch (message.type) {
       case "setProperties":
         if (message.title) {
-          photonPageAction.title = message.title;
+          photonPageAction.setTitle(message.title);
         }
         if (message.iconPath) {
-          photonPageAction.iconURL = webExtension.extension.getURL(message.iconPath);
+          photonPageAction.setIconURL(webExtension.extension.getURL(message.iconPath));
         }
         break;
       default:


### PR DESCRIPTION
Bug 1395387 changed the Photon page action API so that `title`
and `iconURL` are no longer properties but methods, setTitle()
and setIconURL().  We need to update our consumer.  Right now,
setting these properties isn't doing anything at all.