### PR TITLE
Fix #3599, set the left position of the full page cutoff warning

### DIFF
--- a/static/css/inline-selection.scss
+++ b/static/css/inline-selection.scss
@@ -514,6 +514,7 @@ $very-light-grey: #ededed;
 #imageCroppedWarning {
   position: absolute;
   background: rgba(0, 0, 0, 0.8);
+  left: 0;
   bottom: 0;
   color: #fff;
   font-family: -apple-system, BlinkMacSystemFont, "segoe ui", "helvetica neue", helvetica, ubuntu, roboto, noto, arial, sans-serif;


### PR DESCRIPTION
It's slightly mysterious why the warning doesn't display consistently, and any CSS fiddling will fix it, even if all rules are put back as they were. Setting the left position seems to fix this, but for unknown reasons.