### PR TITLE
Fix bug in shot id regular expression

### DIFF
--- a/shared/shot.js
+++ b/shared/shot.js
@@ -209,7 +209,7 @@ class AbstractShot {
 
   constructor(backend, id, attrs) {
     attrs = attrs || {};
-    assert((/^[a-zA-Z0-9]{1,4000}\/[a-z0-9.-_]{1,4000}$/).test(id), "Bad ID (should be alphanumeric):", JSON.stringify(id));
+    assert((/^[a-zA-Z0-9]{1,4000}\/[a-z0-9._-]{1,4000}$/).test(id), "Bad ID (should be alphanumeric):", JSON.stringify(id));
     this._backend = backend;
     this._id = id;
     this.origin = attrs.origin || null;


### PR DESCRIPTION
The regex was meant to match '-', but the dash was treated as a range