### PR TITLE
Fix bug when UITour-lib.js loads after homepage-bundle.js

### DIFF
--- a/server/src/pages/homepage/controller.js
+++ b/server/src/pages/homepage/controller.js
@@ -29,6 +29,7 @@ document.addEventListener("addon-present", () => {
             }
             return;
           }
+          clearTimeout(interval);
           Mozilla.UITour.showHighlight("screenshots");
         }, 100);
       } else {

--- a/server/src/pages/homepage/controller.js
+++ b/server/src/pages/homepage/controller.js
@@ -17,7 +17,23 @@ document.addEventListener("addon-present", () => {
     document.dispatchEvent(new CustomEvent("request-onboarding"));
   } else if (location.hash === "#tour") {
     try {
-      Mozilla.UITour.showHighlight("screenshots");
+      if (typeof Mozilla == "undefined") {
+        // The UITour-lib.js library hasn't loaded yet
+        let count = 10;
+        let interval = setInterval(() => {
+          if (typeof Mozilla == "undefined") {
+            count--;
+            if (count <= 0) {
+              clearTimeout(interval);
+              throw new Error("UITour-lib.js didn't load up after 1 second");
+            }
+            return;
+          }
+          Mozilla.UITour.showHighlight("screenshots");
+        }, 100);
+      } else {
+        Mozilla.UITour.showHighlight("screenshots");
+      }
     } catch (e) {
       console.warn("Attempted to start #tour on non-Firefox version or unsupported version");
       throw e;


### PR DESCRIPTION
The UITour-lib.js library is loaded async, and the homepage-bundle can potentially load and run before it (we saw this in Sentry). This puts in a 1 second retry when that happens.