### PR TITLE
Update css class name to restore download-only tooltip.

### DIFF
--- a/addon/webextension/selector/ui.js
+++ b/addon/webextension/selector/ui.js
@@ -100,7 +100,7 @@ this.ui = (function() { // eslint-disable-line no-unused-vars
   function renderDownloadNotice(initAtBottom = false) {
     let notice = makeEl("table", "notice");
     notice.innerHTML = `
-      <div class="download-only-details">
+      <div class="notice-tooltip">
         <p data-l10n-id="downloadOnlyDetails"></p>
         <ul>
           <li data-l10n-id="downloadOnlyDetailsPrivate"></li>
@@ -110,7 +110,7 @@ this.ui = (function() { // eslint-disable-line no-unused-vars
       <tbody>
         <tr class="notice-wrapper">
           <td class="notice-content" data-l10n-id="downloadOnlyNotice"></td>
-          <td class="download-only-help"></td>
+          <td class="notice-help"></td>
         </tr>
       <tbody>`;
     localizeText(notice);

--- a/static/css/inline-selection.scss
+++ b/static/css/inline-selection.scss
@@ -220,7 +220,7 @@ $very-light-grey: #ededed;
     white-space: nowrap;
   }
 
-  .download-only-help {
+  .notice-help {
     background-image: url("MOZ_EXTENSION/icons/help-16.svg");
     background-position: center center;
     background-repeat: no-repeat;
@@ -229,7 +229,7 @@ $very-light-grey: #ededed;
   }
 }
 
-.download-only-details {
+.notice-tooltip {
   background: #fff;
   border-radius: 3px;
   border: 1px solid #9d9d9e;
@@ -249,7 +249,7 @@ $very-light-grey: #ededed;
   width: 300px;
   z-index: $overlay-z-index + 1;
 
-  .download-only:hover & {
+  .notice:hover & {
     display: block;
   }
 


### PR DESCRIPTION
Fix #3780