### PR TITLE
Fix remaining domain regexes

### DIFF
--- a/addon/webextension/domainFromUrl.js
+++ b/addon/webextension/domainFromUrl.js
@@ -14,10 +14,10 @@ this.domainFromUrl = (function() {
         domain = "unknown";
       }
     }
-    if (domain.search(/^[a-z0-9.-_]{1,1000}$/i) === -1) {
+    if (domain.search(/^[a-z0-9._-]{1,1000}$/i) === -1) {
       // Probably a unicode domain; we could use punycode but it wouldn't decode
       // well in the URL anyway.  Instead we'll punt.
-      domain = domain.replace(/[^a-z0-9.-_]/ig, "");
+      domain = domain.replace(/[^a-z0-9._-]/ig, "");
       if (!domain) {
         domain = "site";
       }

--- a/shared/shot.js
+++ b/shared/shot.js
@@ -29,7 +29,7 @@ function isUrl(url) {
   if ((/^view-source:/i).test(url)) {
     return isUrl(url.substr("view-source:".length));
   }
-  return (/^https?:\/\/[a-z0-9.-_]{1,8000}[a-z0-9](:[0-9]{1,8000})?\/?/i).test(url);
+  return (/^https?:\/\/[a-z0-9._-]{1,8000}[a-z0-9](:[0-9]{1,8000})?\/?/i).test(url);
 }
 
 function isValidClipImageUrl(url) {
@@ -48,7 +48,7 @@ function assertUrl(url) {
 }
 
 function isSecureWebUri(url) {
-  return (/^https?:\/\/[a-z0-9.-_]{1,8000}[a-z0-9](:[0-9]{1,8000})?\/?/i).test(url);
+  return (/^https?:\/\/[a-z0-9._-]{1,8000}[a-z0-9](:[0-9]{1,8000})?\/?/i).test(url);
 }
 
 function assertOrigin(url) {
@@ -129,7 +129,7 @@ function resolveUrl(base, url) {
   }
   if (url.indexOf("/") === 0) {
     // Domain-relative URL
-    return (/^https?:\/\/[a-z0-9.-_]{1,4000}/i).exec(base)[0] + url;
+    return (/^https?:\/\/[a-z0-9._-]{1,4000}/i).exec(base)[0] + url;
   }
   // Otherwise, a full relative URL
   while (url.indexOf("./") === 0) {

--- a/static/js/wantsauth.js
+++ b/static/js/wantsauth.js
@@ -25,7 +25,7 @@ window.wantsauth = (function() {
   // authentication.  As a result we have to parse the URL on our own:
   let maybeShotId = location.href.replace(/^https?:\/\/[^/]{1,4000}\//i, "");
   maybeShotId = maybeShotId.replace(/\?.*/, "").replace(/#.{0,4000}/, "");
-  if (maybeShotId.search(/[a-z0-9]+\/[a-z0-9.-_]{1,4000}$/i) === -1) {
+  if (maybeShotId.search(/[a-z0-9]+\/[a-z0-9._-]{1,4000}$/i) === -1) {
     // Not a shot ID, which should look like {stuff}/{stuff}
     maybeShotId = null;
   }


### PR DESCRIPTION
This is a followup to 2bd42beed9f18f626e328fa73f2dd6fd8be57e6f that applies the same fix to other regular expressions