### PR TITLE
Track the number of copied shots in Telemetry

### DIFF
--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -234,6 +234,9 @@ function handleMessage(msg, sender, sendReply) {
   } else if (msg.funcName === "incrementUploadCount") {
     Services.telemetry.scalarAdd('screenshots.upload', 1);
     sendReply({type: "success", value: true});
+  } else if (msg.funcName === "incrementCopyCount") {
+    Services.telemetry.scalarAdd('screenshots.copy', 1);
+    sendReply({type: "success", value: true});
   }
 }
 

--- a/addon/webextension/background/main.js
+++ b/addon/webextension/background/main.js
@@ -209,6 +209,7 @@ this.main = (function() {
     return blobConverters.blobToArray(blob).then(buffer => {
       return browser.clipboard.setImageData(
         buffer, blob.type.split("/", 2)[1]).then(() => {
+          catcher.watchPromise(communication.sendToBootstrap('incrementCopyCount'));
           return browser.notifications.create({
             type: "basic",
             iconUrl: "../icons/copy.png",


### PR DESCRIPTION
While reviewing the export patch for version 25, I realized we aren't incrementing the Telemetry counter when shots are copied.