### PR TITLE
Handle the boundary case where the user deletes the last shot of a page

### DIFF
--- a/server/src/pages/shotindex/controller.js
+++ b/server/src/pages/shotindex/controller.js
@@ -136,6 +136,10 @@ exports.deleteShot = function(shot) {
       errorMessage = errorMessage.replace('{statusText}', req.statusText);
       window.alert(errorMessage);
       window.Raven.captureException(new Error(`Error calling /api/delete-shot: ${req.status} ${req.statusText}`));
+    } else if ((model.totalShots % model.shotsPerPage) === 1 && model.pageNumber > 1) {
+      // On the boundary case where the user deletes the last image on a page
+      // (where page number > 1), we need to decrement the page number.
+      exports.onChangePage(model.pageNumber - 1);
     } else {
       refreshModel();
     }


### PR DESCRIPTION
Fix #3779