### PR TITLE
Skip test_file_managemnt tests by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "posttest": "npm run lint",
     "test": "make bootstrap_zip && mocha test/ test/server/unit/*",
     "test:selenium": "make bootstrap_zip && mocha test/test.js",
-    "test:server": "make .venv && cd test/server && ../../.venv/bin/pytest",
+    "test:server": "make .venv && cd test/server && ../../.venv/bin/pytest -m 'not slow'",
     "make_versions_exact": "node bin/build-scripts/make_versions_exact.js",
     "update_outdated": "david update && npm run make_versions_exact && npm update && npm outdated",
     "fill_database": "make .venv && ./.venv/bin/python  ./bin/load_test_exercise.py -q --little-image --create=50 --read-shot=0 --read-my-shots=0 --search=0 --new-account http://localhost:10080"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    slow: Slow tests, skip this module.
+

--- a/test/server/test_file_management.py
+++ b/test/server/test_file_management.py
@@ -5,6 +5,7 @@ import time
 import atexit
 from sarge import Capture, run
 import pytest
+pytestmark = pytest.mark.slow
 
 SERVER_URL = "http://localhost:10180"
 
@@ -23,7 +24,6 @@ def make_session():
     return session
 
 
-@pytest.mark.skip(reason="Too slow to run")
 def test_s3_upload():
     restart_server()
     session = make_session()
@@ -33,7 +33,6 @@ def test_s3_upload():
     assert read_file(page["clip_url"]) == get_url(page["clip_url"])
 
 
-@pytest.mark.skip(reason="Too slow to run")
 def test_s3_expire():
     restart_server()
     session = make_session()
@@ -49,7 +48,6 @@ def test_s3_expire():
     get_url(shot_url, expect=200)
 
 
-@pytest.mark.skip(reason="Too slow to run")
 def test_s3_delete():
     restart_server()
     session = make_session()
@@ -62,7 +60,6 @@ def test_s3_delete():
     assert read_file(page["clip_url"]) is None
 
 
-@pytest.mark.skip(reason="Too slow to run")
 def test_s3_delete_after_expire():
     restart_server(DEFAULT_EXPIRATION=1)
     session = make_session()
@@ -79,7 +76,6 @@ def test_s3_delete_after_expire():
     assert read_file(page["clip_url"]) is None
 
 
-@pytest.mark.skip(reason="Too slow to run")
 def test_s3_final_expire():
     restart_server(EXPIRED_RETENTION_TIME=1, CHECK_DELETED_INTERVAL="0.1")
     session = make_session()


### PR DESCRIPTION
Add a marker for slow tests. And skip test_file_managements.py with that marker.

Closes #3421 