### PR TITLE
Clear cached highlighted element when hiding hover box.

### DIFF
--- a/addon/webextension/selector/uicontrol.js
+++ b/addon/webextension/selector/uicontrol.js
@@ -437,6 +437,9 @@ this.uicontrol = (function() {
           (!event.target.classList.contains("preview-overlay"))) {
         // User is hovering over a toolbar button or control
         autoDetectRect = null;
+        if (this.cachedEl) {
+          this.cachedEl = null;
+        }
         ui.HoverBox.hide();
         return;
       }


### PR DESCRIPTION
Fix #3970