### PR TITLE
Check capture type before it's potentially changed

### DIFF
--- a/addon/webextension/selector/uicontrol.js
+++ b/addon/webextension/selector/uicontrol.js
@@ -201,15 +201,15 @@ this.uicontrol = (function() {
     onDownloadPreview: () => {
       sendEvent(`download-${captureType.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase()}`, "download-preview-button");
       // Downloaded shots don't have dimension limits
-      removeDimensionLimitsOnFullPageShot();
       let previewDataUrl = (captureType === "fullPageTruncated") ? null : dataUrl;
+      removeDimensionLimitsOnFullPageShot();
       shooter.downloadShot(selectedPos, previewDataUrl);
     },
     onCopyPreview: () => {
       sendEvent(`copy-${captureType.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase()}`, "copy-preview-button");
       // Copied shots don't have dimension limits
-      removeDimensionLimitsOnFullPageShot();
       let previewDataUrl = (captureType === "fullPageTruncated") ? null : dataUrl;
+      removeDimensionLimitsOnFullPageShot();
       shooter.copyShot(selectedPos, previewDataUrl);
     }
   };


### PR DESCRIPTION
Fixes #3968 

Fixes a bug introduced by previous patch for #3968.  Variable scopes, man. 😩 