### PR TITLE
Remove special click handlers for onboarding legal and terms links

### DIFF
--- a/addon/webextension/background/main.js
+++ b/addon/webextension/background/main.js
@@ -287,16 +287,6 @@ this.main = (function() {
     });
   });
 
-  // Note: this signal is only needed until bug 1357589 is fixed.
-  communication.register("openTermsPage", () => {
-    return catcher.watchPromise(browser.tabs.create({url: "https://www.mozilla.org/about/legal/terms/services/"}));
-  });
-
-  // Note: this signal is also only needed until bug 1357589 is fixed.
-  communication.register("openPrivacyPage", () => {
-    return catcher.watchPromise(browser.tabs.create({url: "https://www.mozilla.org/privacy/firefox-cloud/"}));
-  });
-
   // A Screenshots page wants us to start/force onboarding
   communication.register("requestOnboarding", (sender) => {
     return startSelectionWithOnboarding(sender.tab);

--- a/addon/webextension/onboarding/slides.js
+++ b/addon/webextension/onboarding/slides.js
@@ -144,16 +144,6 @@ this.slides = (function() {
       shooter.sendEvent("finish-slides", "done");
       callbacks.onEnd();
     })));
-    // Note: e10s breaks the terms and privacy anchor tags. Work around this by
-    // manually opening the correct URLs on click until bug 1357589 is fixed.
-    doc.querySelector("#terms").addEventListener("click", watchFunction(assertIsTrusted((event) => {
-      event.preventDefault();
-      callBackground("openTermsPage");
-    })));
-    doc.querySelector("#privacy").addEventListener("click", watchFunction(assertIsTrusted((event) => {
-      event.preventDefault();
-      callBackground("openPrivacyPage");
-    })));
     doc.querySelector("#slide-overlay").addEventListener("click", watchFunction(assertIsTrusted((event) => {
       if (event.target == doc.querySelector("#slide-overlay")) {
         shooter.sendEvent("cancel-slides", "background-click");


### PR DESCRIPTION
[Bug 1357589](https://bugzil.la/1357589) has been fixed, so the links should now behave normally.

Refs #2699.