### PR TITLE
Suppress errors encountered when sending timing or events pings

### DIFF
--- a/addon/webextension/background/analytics.js
+++ b/addon/webextension/background/analytics.js
@@ -258,7 +258,8 @@ this.analytics = (function() {
           throw new Error(`Bad response from ${request.url}: ${response.status} ${response.statusText}`);
         }
         return response;
-      })
+      }),
+      true
     );
   }
 


### PR DESCRIPTION
With the move to batched pings, the optional second argument to `watchPromise` was dropped, causing haywire errors if users did anything with Screenshots while the network is unreachable. This patch restores that second argument, preventing analytics-related network errors from being shown to users.