### PR TITLE
Cancel user timings when the window becomes hidden

### DIFF
--- a/addon/webextension/background/analytics.js
+++ b/addon/webextension/background/analytics.js
@@ -162,27 +162,42 @@ this.analytics = (function() {
     name: 'page-action',
     start: { action: 'start-shot', label: 'toolbar-button' },
     end: { action: 'internal', label: 'unhide-preselection-frame' },
-    cancel: [{ action: 'cancel-shot' }]
+    cancel: [
+      { action: 'cancel-shot' },
+      { action: 'internal', label: 'document-hidden' }
+    ]
   }, {
     name: 'context-menu',
     start: { action: 'start-shot', label: 'context-menu' },
     end: { action: 'internal', label: 'unhide-preselection-frame' },
-    cancel: [{ action: 'cancel-shot' }]
+    cancel: [
+      { action: 'cancel-shot' },
+      { action: 'internal', label: 'document-hidden' }
+    ]
   }, {
     name: 'capture-full-page',
     start: { action: 'capture-full-page' },
     end: { action: 'internal', label: 'unhide-preview-frame' },
-    cancel: [{ action: 'cancel-shot' }]
+    cancel: [
+      { action: 'cancel-shot' },
+      { action: 'internal', label: 'document-hidden' }
+    ]
   }, {
     name: 'capture-visible',
     start: { action: 'capture-visible' },
     end: { action: 'internal', label: 'unhide-preview-frame' },
-    cancel: [{ action: 'cancel-shot' }]
+    cancel: [
+      { action: 'cancel-shot' },
+      { action: 'internal', label: 'document-hidden' }
+    ]
   }, {
     name: 'make-selection',
     start: { action: 'make-selection' },
     end: { action: 'internal', label: 'unhide-selection-frame' },
-    cancel: [{ action: 'cancel-shot' }]
+    cancel: [
+      { action: 'cancel-shot' },
+      { action: 'internal', label: 'document-hidden' }
+    ]
   }, {
     name: 'save-shot',
     start: { action: 'save-shot' },
@@ -207,22 +222,34 @@ this.analytics = (function() {
     name: 'download-shot',
     start: { action: 'download-shot' },
     end: { action: 'internal', label: 'deactivate' },
-    cancel: [{ action: 'cancel-shot' }]
+    cancel: [
+      { action: 'cancel-shot' },
+      { action: 'internal', label: 'document-hidden' }
+    ]
   }, {
     name: 'download-full-page',
     start: { action: 'download-full-page' },
     end: { action: 'internal', label: 'deactivate' },
-    cancel: [{ action: 'cancel-shot' }]
+    cancel: [
+      { action: 'cancel-shot' },
+      { action: 'internal', label: 'document-hidden' }
+    ]
   }, {
     name: 'download-full-page-truncated',
     start: { action: 'download-full-page-truncated' },
     end: { action: 'internal', label: 'deactivate' },
-    cancel: [{ action: 'cancel-shot' }]
+    cancel: [
+      { action: 'cancel-shot' },
+      { action: 'internal', label: 'document-hidden' }
+    ]
   }, {
     name: 'download-visible',
     start: { action: 'download-visible' },
     end: { action: 'internal', label: 'deactivate' },
-    cancel: [{ action: 'cancel-shot' }]
+    cancel: [
+      { action: 'cancel-shot' },
+      { action: 'internal', label: 'document-hidden' }
+    ]
   }];
 
   // Match a filter (action and optional label) against an action and label.

--- a/addon/webextension/selector/uicontrol.js
+++ b/addon/webextension/selector/uicontrol.js
@@ -962,6 +962,7 @@ this.uicontrol = (function() {
     });
     primedDocumentHandlers.set("keyup", watchFunction(assertIsTrusted(keyupHandler)));
     primedDocumentHandlers.set("keydown", watchFunction(assertIsTrusted(keydownHandler)));
+    window.document.addEventListener("visibilitychange", visibilityChangeHandler);
     window.addEventListener('beforeunload', beforeunloadHandler);
   }
 
@@ -1026,8 +1027,16 @@ this.uicontrol = (function() {
     }
   }
 
+  function visibilityChangeHandler(event) {
+    // The document is the event target
+    if (event.target.hidden) {
+      sendEvent("internal", "document-hidden");
+    }
+  }
+
   function removeHandlers() {
     window.removeEventListener("beforeunload", beforeunloadHandler);
+    window.document.removeEventListener("visibilitychange", visibilityChangeHandler);
     for (let {name, doc, handler, useCapture} of registeredDocumentHandlers) {
       doc.removeEventListener(name, handler, !!useCapture);
     }


### PR DESCRIPTION
Cancel some user timing measurements when page visibility changes to 'hidden'. Fixes #4055.

JS background budgeting in Firefox 58 might cause Screenshots execution to slow down if the user switches tabs while waiting for the UI to update. Exclude cases where the user timing event ends with an upload, since the result of a successful upload is to switch tabs (to the shot page of the uploaded shot).