### PR TITLE
Update to fluent 0.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "envc": "2.5.0",
     "escape-html": "1.0.3",
     "express": "4.16.2",
-    "fluent": "0.4.1",
+    "fluent": "0.4.3",
     "fluent-intl-polyfill": "0.1.0",
     "fluent-langneg": "0.1.0",
     "fluent-react": "0.4.1",


### PR DESCRIPTION
Please update the `fluent` dependency to 0.4.3.  It has important fixes to the FTL parser.

While the main development of `fluent` continues with the recent 0.6.x versions, I also published 0.4.3 which is API-compatible with other 0.4.x versions. The upgrade should be painless.

`fluent` 0.4.3 supports the recent changes to the Fluent Syntax. It also supports the syntax Screenshots and Pontoon use right now. We expect Pontoon to upgrade their Fluent dependencies early next week, at which point all translations saved back to GitHub will be serialized using the new syntax. This PR will minimize the risk of regressions from that update (which is already low because the changes to the syntax are small).

Some of the syntax changes will require an update to the en-US reference file in this repo, too. We'll open a new PR for that once Pontoon is capable of reading it.

cc @flodolo and @zbraniecki who will be around next week to assist in case of questions.