### PR TITLE
Fix #3776 - Ensure DB returned rows before trying to access them

### DIFF
--- a/server/src/servershot.js
+++ b/server/src/servershot.js
@@ -621,6 +621,9 @@ Shot.setExpiration = function(backend, shotId, deviceId, expiration, accountId) 
     `,
     [shotId, deviceId, accountId]
   ).then((rows) => {
+    if (!rows.length) {
+      return null;
+    }
     const id = rows[0].id;
     if (expiration === 0) {
       return db.update(
@@ -659,6 +662,9 @@ Shot.deleteShot = function(backend, shotId, deviceId, accountId) {
       `,
       [shotId, deviceId, accountId]
   ).then((rows) => {
+    if (!rows.length) {
+      return null;
+    }
     id = rows[0].id;
     return Shot.get(backend, shotId, id)
     .then((shot) => {


### PR DESCRIPTION
Add a couple of empty result checks. The APIs in server.js expect a null result if records weren't found.

This doesn't change user-facing behavior: if the shot is gone, then you try to set expiration or delete it, an error alert is shown. I guess this will avoid errors getting sent to sentry, though.

Verifying this works: create a shot, open shot page in two tabs. Delete the shot from tab 1, then try to set expiration and delete the shot from tab 2.