### PR TITLE
Fix #3771 - Check for S3 errors when accessing bucket

### DIFF
--- a/server/src/servershot.js
+++ b/server/src/servershot.js
@@ -112,7 +112,11 @@ if (!config.useS3) {
 
   get = (uid, contentType) => {
     return new Promise((resolve, reject) => {
-      s3bucket.createBucket(() => {
+      s3bucket.createBucket((err) => {
+        if (err) {
+          mozlog.error("error-getting-bucket", {err});
+          reject(err);
+        }
         const params = {Key: uid};
         s3bucket.getObject(params, function(err, data) {
           if (err) {


### PR DESCRIPTION
Re: description of #3771, I'm not sure this error check is worth merging.

I looked at where the `get()` function is used, and didn't see a spot where a promise rejection might get dropped. Noticed that we don't check errors in the outer `createBucket` call, so, _maybe_ that's relevant? Our usage of the aws-sdk API diverges from the docs on the aws site (we don't pass params into the `createBucket` call, but into the constructor), so maybe there's some other undocumented behavior where errors get handled in the inner callback?