### PR TITLE
Fix #3642, Require node 8 for docker and in package.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:7
+FROM node:8
 
 COPY package.json /app/
 COPY build/server /app/build/server

--- a/package.json
+++ b/package.json
@@ -77,6 +77,9 @@
     "uglifyify": "4.0.4",
     "web-ext": "2.1.0"
   },
+  "engines": {
+    "node": ">=8.0.0"
+  },
   "homepage": "https://screenshots.firefox.com",
   "license": "MPL-2.0",
   "repository": {


### PR DESCRIPTION
@oremj I'm not running Docker locally. Do you know of any issues to worry about with bumping our Docker base image from node:7 to node:8, maybe bugs other services have run into?

Also, I'm guilty of skipping the eslint-related changes @pdehaan suggested in #3642...we can add those to a separate good-first-bug for node linting, maybe?