### PR TITLE
Fix DPI scaling in download/copy 

### DIFF
--- a/addon/webextension/selector/shooter.js
+++ b/addon/webextension/selector/shooter.js
@@ -84,9 +84,7 @@ this.shooter = (function() { // eslint-disable-line no-unused-vars
     }
     const canvas = captureToCanvas(selectedPos, captureType);
     ui.iframe.showLoader();
-    const width = selectedPos.right - selectedPos.left;
-    const height = selectedPos.bottom - selectedPos.top;
-    const imageData = canvas.getContext("2d").getImageData(0, 0, width, height);
+    const imageData = canvas.getContext("2d").getImageData(0, 0, canvas.width, canvas.height);
     return callBackground("canvasToDataURL", imageData);
   }
 
@@ -180,8 +178,8 @@ this.shooter = (function() { // eslint-disable-line no-unused-vars
     }));
   };
 
-  exports.downloadShot = function(selectedPos, previewDataUrl) {
-    const shotPromise = previewDataUrl ? Promise.resolve(previewDataUrl) : screenshotPageAsync(selectedPos, "fullPage");
+  exports.downloadShot = function(selectedPos, previewDataUrl, type) {
+    const shotPromise = previewDataUrl ? Promise.resolve(previewDataUrl) : screenshotPageAsync(selectedPos, type);
     catcher.watchPromise(shotPromise.then(dataUrl => {
       let promise = Promise.resolve(dataUrl);
       if (!dataUrl) {
@@ -214,7 +212,7 @@ this.shooter = (function() { // eslint-disable-line no-unused-vars
   };
 
   let copyInProgress = null;
-  exports.copyShot = function(selectedPos, previewDataUrl) {
+  exports.copyShot = function(selectedPos, previewDataUrl, type) {
     // This is pretty slow. We'll ignore additional user triggered copy events
     // while it is in progress.
     if (copyInProgress) {
@@ -231,7 +229,7 @@ this.shooter = (function() { // eslint-disable-line no-unused-vars
         copyInProgress = null;
       }
     }
-    const shotPromise = previewDataUrl ? Promise.resolve(previewDataUrl) : screenshotPageAsync(selectedPos, "fullPage");
+    const shotPromise = previewDataUrl ? Promise.resolve(previewDataUrl) : screenshotPageAsync(selectedPos, type);
     catcher.watchPromise(shotPromise.then(dataUrl => {
       const blob = blobConverters.dataUrlToBlob(dataUrl);
       catcher.watchPromise(callBackground("copyShotToClipboard", blob).then(() => {

--- a/addon/webextension/selector/uicontrol.js
+++ b/addon/webextension/selector/uicontrol.js
@@ -99,14 +99,14 @@ this.uicontrol = (function() {
     const previewDataUrl = (captureType === "fullPageTruncated") ? null : dataUrl;
     // Downloaded shots don't have dimension limits
     removeDimensionLimitsOnFullPageShot();
-    shooter.downloadShot(selectedPos, previewDataUrl);
+    shooter.downloadShot(selectedPos, previewDataUrl, captureType);
   }
 
   function copyShot() {
     const previewDataUrl = (captureType === "fullPageTruncated") ? null : dataUrl;
     // Copied shots don't have dimension limits
     removeDimensionLimitsOnFullPageShot();
-    shooter.copyShot(selectedPos, previewDataUrl);
+    shooter.copyShot(selectedPos, previewDataUrl, captureType);
   }
 
   /** *********************************************


### PR DESCRIPTION
Fixes #4174. Changes:

* don't overwrite correctly-scaled canvas dimensions
* pass the shot type to `downloadShot` and `copyShot`

@chenba Mind taking a look? I git bisected the bug back to commit 6fa7f3a8a, but I may not have all the context around the reasons for the changes in that commit. In particular, I'm curious if "fullPage" was hard-coded for any particular reason.