### PR TITLE
Pass in locale for date.toLocaleString.

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -14,5 +14,6 @@ USER_SETTINGS=true
 ENABLE_ANNOTATIONS=true
 SCREENSHOTS_UPLOAD_BINARY=true
 
+export NODE_ICU_DATA="$(pwd)/node_modules/full-icu"
 export NO_UGLIFY=true
 export NODE_ENV=dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ COPY build/shared /app/build/shared
 COPY node_modules /app/node_modules
 COPY bin/_run-docker /app/bin/
 COPY build/screenshots.xpi /app/build/xpi/screenshots.xpi
+ENV NODE_ICU_DATA="/app/node_modules/full-icu"
 RUN cd app && npm install
 
 CMD /app/bin/_run-docker

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "fluent-intl-polyfill": "0.1.0",
     "fluent-langneg": "0.1.0",
     "fluent-react": "0.4.1",
+    "full-icu": "1.2.1",
     "jpm": "1.3.1",
     "keygrip": "1.0.2",
     "mobile-detect": "1.3.7",

--- a/server/src/pages/shot/time-diff.js
+++ b/server/src/pages/shot/time-diff.js
@@ -64,10 +64,14 @@ exports.TimeDiff = class TimeDiff extends React.Component {
     if (!(d instanceof Date)) {
       d = new Date(d);
     }
+    if (this.props.userLocales && this.props.userLocales.length) {
+      return d.toLocaleString(this.props.userLocales[0]);
+    }
     return d.toLocaleString();
   }
 };
 
 exports.TimeDiff.propTypes = {
-  date: PropTypes.number
+  date: PropTypes.number,
+  userLocales: PropTypes.array
 }

--- a/server/src/pages/shot/view.js
+++ b/server/src/pages/shot/view.js
@@ -334,7 +334,7 @@ class Body extends React.Component {
 
     const linkTextShort = shot.urlDisplay;
 
-    const timeDiff = <TimeDiff date={shot.createdDate} />;
+    const timeDiff = <TimeDiff date={shot.createdDate} userLocales={this.props.userLocales} />;
     let expiresDiff = null;
     if (this.props.isOwner) {
       expiresDiff = <span className="expire-widget">
@@ -567,7 +567,8 @@ Body.propTypes = {
   showSurveyLink: PropTypes.bool,
   shot: PropTypes.object,
   staticLink: PropTypes.func,
-  userAgent: PropTypes.string
+  userAgent: PropTypes.string,
+  userLocales: PropTypes.array
 };
 
 class ExpireWidget extends React.Component {


### PR DESCRIPTION
Fixes #2216 

Because default node build only supports en-US, we need to either build node with --full-icu or provide ICU data at runtime; this patch does the latter.