### PR TITLE
Disable three tests temporarily.

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -267,7 +267,8 @@ describe("Test Screenshots", function() {
     }).catch(done);
   });
 
-  it("should take an auto selection shot", function(done) {
+  // Temporarily disabled.  See https://github.com/mozilla-services/screenshots/issues/4240
+  xit("should take an auto selection shot", function(done) {
     startAutoSelectionShot(driver).then(() => {
       return driver.wait(until.elementLocated(By.css(".highlight-button-save")));
     }).then((saveButton) => {
@@ -325,7 +326,8 @@ describe("Test Screenshots", function() {
     }).catch(done);
   });
 
-  it("should download a shot", function(done) {
+  // Temporarily disabled.  See https://github.com/mozilla-services/screenshots/issues/4240
+  xit("should download a shot", function(done) {
     const startingFileCount = fs.readdirSync(downloadDir).length;
     const filenameRegex = /^Screenshot.+ Firefox Screenshots\.png$/;
     let files;
@@ -362,7 +364,8 @@ describe("Test Screenshots", function() {
     .catch(done);
   });
 
-  it("should remain on original tab with UI overlay on save failure", function(done) {
+  // Temporarily disabled.  See https://github.com/mozilla-services/screenshots/issues/4240
+  xit("should remain on original tab with UI overlay on save failure", function(done) {
     const badAddon = path.join(process.cwd(), "build", "screenshots-bootstrap-server-down.zip");
     driver.installAddon(badAddon)
     .then(() => startAutoSelectionShot(driver))


### PR DESCRIPTION
Disable three tests that are failing because of changes in Firefox.  (See #4240)