### PR TITLE
Fix last step in fxa oauth flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "morgan": "1.9.0",
     "mozlog": "2.1.1",
     "multer": "1.3.0",
+    "node-fetch": "2.1.2",
     "node-statsd": "0.1.1",
     "nodemon": "1.12.1",
     "nodify-uuid": "0.0.1",
@@ -45,8 +46,7 @@
     "rimraf": "2.6.2",
     "universal-analytics": "0.4.15",
     "uuid": "3.1.0",
-    "valid-url": "1.0.9",
-    "wreck": "13.0.3"
+    "valid-url": "1.0.9"
   },
   "devDependencies": {
     "addons-linter": "0.27.0",

--- a/server/src/helpers.js
+++ b/server/src/helpers.js
@@ -1,32 +1,4 @@
 const crypto = require("crypto");
-const wreck = require("wreck");
-
-exports.request = function request(method, uri, options) {
-  return new Promise((resolve, reject) => {
-    wreck.request(method, uri, options, function afterWreck(err, res) {
-      if (err) {
-        reject(err);
-        return;
-      }
-      resolve(res);
-    });
-  }).then(res => {
-    return exports.readBody(res, options).then(body => [res, body]);
-  });
-};
-
-// Collects an incoming message body into a buffer.
-exports.readBody = function readBody(req, options) {
-  return new Promise((resolve, reject) => {
-    return wreck.read(req, options, function afterRead(err, body) {
-      if (err) {
-        reject(err);
-        return;
-      }
-      resolve(body);
-    });
-  });
-};
 
 exports.randomBytes = function randomBytes(size) {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
*Edited: this PR is now a complete fix for #3681.*

Partial fix for #3681. The implementation of the `request` and `readBody` methods inside `helpers.js` assumed that the wrapped `wreck` methods were callback-based, but those methods actually return promises, so the promise chain wasn't terminated properly. I don't see any need for the helpers, so just invoked the `wreck` methods directly.

@niharikak101 Does this unblock you with fxa debugging?

Without this patch, when I do the fxa login flow on localhost, it hangs forever after entering the password and confirmation code. (When I do the same on the dev server, as in the STR for #3681, I see a 504 Gateway Timeout after a 60 second wait, which I think is nginx timing out the connection.)

With this patch, when I do the fxa login flow on localhost, I immediately get a 403 error with message "Invalid OAuth access token".

Doesn't fix FxA, but does move the debugging one step forward :+1: