### PR TITLE
Fix #4299: hide the full page button in Chrome mode

### DIFF
--- a/addon/webextension/selector/ui.js
+++ b/addon/webextension/selector/ui.js
@@ -304,7 +304,7 @@ this.ui = (function() { // eslint-disable-line no-unused-vars
                          <div class="spacer"></div>
                        `}
                        <button class="visible" tabindex="2" data-l10n-id="saveScreenshotVisibleArea"></button>
-                       <button class="full-page" tabindex="3" data-l10n-id="saveScreenshotFullPage"></button>
+                       ${isChrome ? "" : `<button class="full-page" tabindex="3" data-l10n-id="saveScreenshotFullPage"></button>`}
                      </div>
                    </div>
                  </div>


### PR DESCRIPTION
Landing in the Chrome branch. (I'll open a separate discussion-only PR to get feedback on the prototype overall.)

Steps to test:
- check out this branch
- `SCREENSHOTS_CHROME_BUILD=true make chrome`
- start chrome, go to `chrome://extensions`, click 'LOAD UNPACKED' in the header, choose the `webextension` directory
- load a website, right-click and choose 'take a screenshot'
- you should see the 'save visible', but not the 'save full page', button in the top-right corner of the preselection iframe:

<img width="1127" alt="screen shot 2018-04-05 at 3 20 36 pm" src="https://user-images.githubusercontent.com/96396/38394852-eccb0c3e-38e4-11e8-846f-17f49594bc6b.png">
