### PR TITLE
Render shot capture time only when in browser

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -14,7 +14,6 @@ USER_SETTINGS=true
 ENABLE_ANNOTATIONS=true
 SCREENSHOTS_UPLOAD_BINARY=true
 
-export NODE_ICU_DATA="$(pwd)/node_modules/full-icu"
 # For false, unset or set to empty string
 export NO_UGLIFY=true
 export NODE_ENV=dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ COPY build/shared /app/build/shared
 COPY node_modules /app/node_modules
 COPY bin/_run-docker /app/bin/
 COPY build/screenshots.xpi /app/build/xpi/screenshots.xpi
-ENV NODE_ICU_DATA="/app/node_modules/full-icu"
 RUN cd app && npm install
 
 CMD /app/bin/_run-docker

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "fluent-intl-polyfill": "0.1.0",
     "fluent-langneg": "0.1.0",
     "fluent-react": "0.4.1",
-    "full-icu": "1.2.1",
     "jpm": "1.3.1",
     "keygrip": "1.0.2",
     "mobile-detect": "1.3.7",

--- a/server/src/pages/shot/time-diff.js
+++ b/server/src/pages/shot/time-diff.js
@@ -61,17 +61,16 @@ exports.TimeDiff = class TimeDiff extends React.Component {
   }
 
   dateString(d) {
+    if (!this.state.useLocalTime) {
+      return "";
+    }
     if (!(d instanceof Date)) {
       d = new Date(d);
-    }
-    if (this.props.userLocales && this.props.userLocales.length) {
-      return d.toLocaleString(this.props.userLocales[0]);
     }
     return d.toLocaleString();
   }
 };
 
 exports.TimeDiff.propTypes = {
-  date: PropTypes.number,
-  userLocales: PropTypes.array
+  date: PropTypes.number
 }

--- a/server/src/pages/shot/view.js
+++ b/server/src/pages/shot/view.js
@@ -331,7 +331,7 @@ class Body extends React.Component {
 
     const linkTextShort = shot.urlDisplay;
 
-    const timeDiff = <TimeDiff date={shot.createdDate} userLocales={this.props.userLocales} />;
+    const timeDiff = <TimeDiff date={shot.createdDate} />;
     let expiresDiff = null;
     if (this.props.isOwner) {
       expiresDiff = <span className="expire-widget">


### PR DESCRIPTION
Fixes #4288 

With this patch, we simply don't render anything for the datetime in the title attribute on the server side.  That also means we can back out the changes made for #2216 (which is a majority of the patch). 🤘 