### PR TITLE
Mask the shot url in the Raven payload.

### DIFF
--- a/server/src/server.js
+++ b/server/src/server.js
@@ -354,6 +354,7 @@ app.get("/install-raven.js", function(req, res) {
   const options = {
     environment: process.env.NODE_ENV || "dev",
     release: linker.getGitRevision(),
+    sanitizeKeys: ["url"],
     serverName: req.backend
   };
   // FIXME: this monkeypatch is because our version of Raven (6.2) doesn't really work


### PR DESCRIPTION
Fixes #3769, requires #4321 as it uses a fairly new option in Raven.

Hold until #4321 is merged.