### PR TITLE
Fix #4338, fix regression in Library link

### DIFF
--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -109,7 +109,7 @@ const LibraryButton = {
     const {nextSibling} = libraryViewInsertionPoint;
     const item = win.document.createElement("toolbarbutton");
     item.className = "subviewbutton subviewbutton-iconic";
-    item.addEventListener("command", () => win.openUILinkIn(this.PAGE_TO_OPEN, "tab"));
+    item.addEventListener("command", () => win.openWebLinkIn(this.PAGE_TO_OPEN, "tab"));
     item.id = this.ITEM_ID;
     const iconURL = this.ICON_URL;
     item.setAttribute("image", iconURL);


### PR DESCRIPTION
The commit https://hg.mozilla.org/mozilla-central/diff/3182593eb59a/browser/base/content/utilityOverlay.js regressed this, requiring a principal for calls to openUILinkIn(). This changes that to the function openWebLinkIn() that provides a null principal.

Note the relevant commit was by @jonathanKingston (r=@gijsk), but since he's not in this project I can't explicitly ask him for a review (though I'd take his review too ;)

I chose `openWebLinkIn()` instead of `openTrustedLinkIn()`, because a lower permission principal seemed safer.