### PR TITLE
[HOLD] Add a keyboard shortcut for Screenshots

### DIFF
--- a/addon/webextension/background/main.js
+++ b/addon/webextension/background/main.js
@@ -130,6 +130,16 @@ this.main = (function() {
   }
 
   exports.onClickedContextMenu = catcher.watchFunction((info, tab) => {
+    onUserInput("context-menu", tab);
+  });
+
+  exports.onKeyboardShortcut = catcher.watchFunction((tab) => {
+    onUserInput("keyboard-shortcut", tab);
+  });
+
+  // command = "context-menu" or "keyboard-shortcut"
+  // Note: new commands should be documented in METRICS.md.
+  function onUserInput (command, tab) {
     if (!tab) {
       // Not in a page/tab context, ignore
       return;
@@ -142,8 +152,8 @@ this.main = (function() {
     }
     catcher.watchPromise(
       toggleSelector(tab)
-        .then(() => sendEvent("start-shot", "context-menu", {incognito: tab.incognito})));
-  });
+        .then(() => sendEvent("start-shot", command, {incognito: tab.incognito})));
+  }
 
   function urlEnabled(url) {
     if (shouldOpenMyShots(url)) {

--- a/addon/webextension/manifest.json.template
+++ b/addon/webextension/manifest.json.template
@@ -18,6 +18,14 @@
       "background/startBackground.js"
     ]
   },
+  "commands": {
+    "take-shot": {
+      "suggested_key": {
+        "default": "Alt+Shift+S",
+        "mac": "Command+Shift+S"
+      }
+    }
+  },
   "content_scripts": [
     {
       "matches": ["http://localhost/*"],

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -110,7 +110,7 @@ The primary change was in `server/src/pages/shot/share-buttons.js`
 #### Add-on metrics
 
 1. [x] Toggle shot button on `addon/start-shot/toolbar-button` (previous to 54 launch the label was `toolbar-pageshot-button`)
-2. [ ] Use keyboard shortcut to start shot `addon/start-shot/keyboard-shortcut` (accel-alt-control-c) (FIXME: not yet implemented)
+2. [x] Use keyboard shortcut to start shot `addon/start-shot/keyboard-shortcut` (Alt + Shift + S, except Command + Shift + S on Mac)
 3. [x] Use the right-click context menu to start a shot `addon/start-shot/context-menu`
 3. [x] Start shot with onboarding because the site requested it (typically a visit to `/#hello`) `addon/start-shot/site-request`
 2. [x] Make a selection `addon/make-selection/selection-drag` with `cd2: {px width}, cd1: {px height}`


### PR DESCRIPTION
* Alt + Shift + S on all platforms, except
* Command + Shift + S on Mac

See https://github.com/mozilla-services/screenshots/issues/2491#issuecomment-383271920 for discussion of the key combination choice.

This choice doesn't seem to conflict with any standard Firefox, Devtools, Windows, or Mac shortcuts.

I also updated METRICS.md to document the new `start-shot` argument.