### PR TITLE
Initialize en-CA content, copying over en-GB

### DIFF
--- a/locales/en-CA/server.ftl
+++ b/locales/en-CA/server.ftl
@@ -1,0 +1,267 @@
+// Localization for Server-side strings of Firefox Screenshots
+// 
+// Please don't localize Firefox, Firefox Screenshots, or Screenshots
+
+
+
+// Global phrases shared across pages, prefixed with 'g'
+[[ global ]]
+
+gMyShots = My Shots
+gHomeLink = Home
+gNoShots
+    .alt = No shots found
+gScreenshotsDescription = Screenshots made simple. Take, save, and share screenshots without leaving Firefox.
+
+
+[[ Footer ]]
+
+// Note: link text for a link to mozilla.org
+footerLinkMozilla = Mozilla
+footerLinkTerms = Terms
+footerLinkPrivacy = Privacy Notice
+footerLinkFaqs = FAQs
+footerLinkDMCA = Report IP Infringement
+footerLinkDiscourse = Give Feedback
+footerLinkRemoveAllData = Remove All Data
+
+
+[[ Creating page ]]
+
+// Note: { $title } is a placeholder for the title of the web page
+// captured in the screenshot. The default, for pages without titles, is
+// creatingPageTitleDefault.
+creatingPageTitle = Creating { $title }
+creatingPageTitleDefault = page
+creatingPageWaitMessage = Saving your shot
+
+
+[[ Home page ]]
+
+homePageDescription
+    .content = Intuitive screenshots baked right into the browser. Capture, save and share screenshots as you browse the Web using Firefox.
+homePageButtonMyShots = Go To My Shots
+homePageTeaser = Coming Soon…
+homePageDownloadFirefoxTitle = Firefox
+homePageDownloadFirefoxSubTitle = Free Download
+homePageGetStarted = Get Started
+// Note: do not translate 'Firefox Screenshots' when translating this string
+homePageHowScreenshotsWorks = How Firefox Screenshots Works
+homePageGetStartedTitle = Get Started
+// Note: Screenshots is an abbreviation for Firefox Screenshots, and should not be translated.
+homePageGetStartedDescription = Find the new Screenshots icon on your toolbar. Select it, and the Screenshots menu will appear on top of your browser window.
+// Note: Screenshots is an abbreviation for Firefox Screenshots, and should not be translated.
+homePageGetStartedDescriptionPageAction = Select the Screenshots icon from the page actions menu in the address bar, and the Screenshots menu will appear on top of your browser window.
+homePageCaptureRegion = Capture a Region
+// Note: Screenshots is an abbreviation for Firefox Screenshots, and should not be translated.
+homePageCaptureRegionDescription = Click and drag to select the area you want to capture. Or just hover and click — Screenshots will select the area for you. Like what you see? Select Save to access your screenshot online or the down arrow button to download it to your computer.
+homePageCapturePage = Capture a Page
+homePageCapturePageDescription = Use the buttons in the upper right to capture full pages. The Save Visible button will capture the area you can view without scrolling, and Save Full Page will capture everything on the page.
+homePageSaveShare = Save and Share
+// Note: Screenshots is an abbreviation for Firefox Screenshots, and should not be translated.
+homePageSaveShareDescription = When you take a shot, Firefox posts your screenshot to your online Screenshots library and copies the link to your clipboard. We automatically store your screenshot for two weeks, but you can delete shots at any time or change the expiration date to keep them in your library for longer.
+homePageLegalLink = Legal
+homePagePrivacyLink = Privacy
+homePageTermsLink = Terms
+homePageCookiesLink = Cookies
+
+
+[[ Leave Screenshots page ]]
+
+leavePageRemoveAllData = Remove All Data
+// Note: do not translate 'Firefox Screenshots' when translating this string
+leavePageErrorAddonRequired = You must have Firefox Screenshots installed to delete your account
+leavePageErrorGeneric = An error occurred
+// Note: do not translate 'Firefox Screenshots' when translating this string
+leavePageWarning = This will permanently erase all of your Firefox Screenshots data.
+leavePageButtonProceed = Proceed
+leavePageButtonCancel = Cancel
+leavePageDeleted = All of your screenshots have been erased!
+
+
+[[ Not Found page ]]
+
+notFoundPageTitle = Page Not Found
+notFoundPageIntro = Oops.
+notFoundPageDescription = Page not found.
+
+
+[[ Shot page ]]
+
+// This is the HTML title tag of the page
+shotPageTitle = Screenshot: { $originalTitle }
+shotPageAlertErrorUpdatingExpirationTime = Error saving expiration
+shotPageAlertErrorDeletingShot = Error deleting shot
+shotPageAlertErrorUpdatingTitle = Error saving title
+shotPageConfirmDelete = Are you sure you want to delete this shot permanently?
+shotPageShareButton
+    .title = Share
+shotPageCopy = Copy
+shotPageCopied = Copied
+shotPageShareFacebook
+    .title = Share on Facebook
+shotPageShareTwitter
+    .title = Share on Twitter
+shotPageSharePinterest
+    .title = Share on Pinterest
+shotPageShareEmail
+    .title = Share link via email
+shotPageShareLink = Get a shareable link to this shot:
+shotPagePrivacyMessage = Anyone with the link can view this shot.
+shotPageCopyImageText
+    .label = Copy image text
+shotPageConfirmDeletion = Are you sure you want to delete this shot permanently?
+// Note: { $timediff } is a placeholder for a future relative time clause like 'in 3 days' or 'tomorrow'
+shotPageExpirationMessage = If you do nothing, this shot will be permanently deleted { $timediff }.
+// Note: { $date } is a placeholder for a localized future date as returned by Date.toLocaleString.
+// For example, in en-US, { $date } could be "7/12/2017, 1:52:50 PM".
+shotPageRestoreButton = restore until { $date }
+shotPageExpiredMessage = This shot has expired.
+// Note: This phrase is followed by an empty line, then the URL of the source page
+shotPageExpiredMessageDetails = Here is the page it was originally created from:
+shotPageDeleteButton
+    .title = Delete this shot
+shotPageAbuseButton
+    .title = Report this shot for abuse, spam, or other problems
+shotPageDownloadShot
+    .title = Download
+shotPageDownload = Download
+shotPageScreenshotsDescription = Screenshots made simple. Take, save, and share screenshots without leaving Firefox.
+shotPageUpsellFirefox = Get Firefox now
+shotPageDMCAMessage = This shot is no longer available due to a third party intellectual property claim.
+// Note: { $dmca } is a placeholder for a link to send email (a 'mailto' link)
+shotPageDMCAContact = Please email { $dmca } to request further information.
+// Note: do not translate 'Firefox Screenshots' when translating this string
+shotPageDMCAWarning = If your Shots are subject to multiple claims, we may revoke your access to Firefox Screenshots.
+// Note: { $url } is a placeholder for a shot page URL
+shotPageDMCAIncludeLink = Please include the URL of this shot in your email: { $url }
+shotPageKeepFor = How long should this shot be retained?
+// Note: shotPageSelectTime is a placeholder label for the time selection dropdown.
+shotPageSelectTime = Select time
+shotPageKeepIndefinitely = Indefinitely
+shotPageKeepTenMinutes = 10 Minutes
+shotPageKeepOneHour = 1 Hour
+shotPageKeepOneDay = 1 Day
+shotPageKeepOneWeek = 1 Week
+shotPageKeepTwoWeeks = 2 Weeks
+shotPageKeepOneMonth = 1 Month
+shotPageSaveExpiration = save
+shotPageCancelExpiration = cancel
+shotPageDoesNotExpire = does not expire
+// Note: { $timediff } is a placeholder for a future relative time clause, like "in 1 week" or "tomorrow"
+shotPageExpiresIn = expires { $timediff }
+// Note: { $timediff } is a placeholder for a past relative time clause, like "1 week ago" or "yesterday"
+shotPageExpired = expired { $timediff }
+timeDiffJustNow = just now
+timeDiffMinutesAgo = { $number ->
+        [one] 1 minute ago
+       *[other] { $number } minutes ago
+    }
+timeDiffHoursAgo = { $number ->
+        [one] 1 hour ago
+       *[other] { $number } hours ago
+    }
+timeDiffDaysAgo = { $number ->
+        [one] yesterday
+       *[other] { $number } days ago
+    }
+timeDiffFutureSeconds = in a few seconds
+timeDiffFutureMinutes = timeDiffFutureMinutes = { $number ->
+        [one] in 1 minute
+       *[other] in { $number } minutes
+    }
+timeDiffFutureHours = timeDiffFutureHours = { $number ->
+        [one] in 1 hour
+       *[other] in { $number } hours
+    }
+timeDiffFutureDays = { $number ->
+        [one] tomorrow
+       *[other] in { $number } days
+    }
+errorThirdPartyCookiesEnabled = If you took this shot and cannot delete it, you may need to temporarily enable third party cookies from your browser’s preferences.
+
+
+[[ Annotations ]]
+
+annotationPenButton
+    .title = Pen
+annotationHighlighterButton
+    .title = Highlighter
+// Note: This button reverts all the changes on the image since the start of the editing session.
+annotationClearButton
+    .title = Clear
+annotationSaveButton = Save
+annotationCancelButton = Cancel
+
+
+[[ Shotindex page ]]
+
+// { $status } is a placeholder for an HTTP status code, like '500'.
+// { $statusText } is a text description of the status code, like 'Internal server error'.
+shotIndexPageErrorDeletingShot = Error deleting shot: { $status } { $statusText }
+// { $searchTerm } is a placeholder for text the user typed into the search box
+shotIndexPageSearchResultsTitle = My Shots: search for { $searchTerm }
+// { $error } is a placeholder for a non-translated error message that could be shared
+// with developers when debugging an error.
+shotIndexPageErrorRendering = Error rendering page: { $error }
+shotIndexPageSearchPlaceholder
+    .placeholder = Search my shots
+shotIndexPageSearchButton
+    .title = Search
+shotIndexPageNoShotsMessage = No saved shots.
+shotIndexPageNoShotsInvitation = Go on, create some.
+shotIndexPageLookingForShots = Looking for your shots…
+shotIndexPageNoSearchResultsIntro = Hmm
+shotIndexPageNoSearchResults = We canʼt find any shots that match your search.
+shotIndexPageClearSearchButton
+    .title = Clear search
+shotIndexPageConfirmShotDelete = Delete this shot?
+shotIndexPagePreviousPage
+    .title = Previous page
+shotIndexPageNextPage
+    .title = Next page
+
+
+// all metrics strings are optional for translation
+[[ Metrics page ]]
+
+// Note: 'Firefox Screenshots' should not be translated
+metricsPageTitle = Firefox Screenshots Metrics
+metricsPageTotalsQueryTitle = Totals
+// Note: Screenshots is an abbreviation for Firefox Screenshots, and should not be translated.
+metricsPageTotalsQueryDescription = An overview of Screenshots
+metricsPageTotalsQueryDevices = Total devices registered
+metricsPageTotalsQueryActiveShots = Active shots
+metricsPageTotalsQueryExpiredShots = Expired (but recoverable)
+metricsPageTotalsQueryExpiredDeletedShots = Expired (and deleted)
+metricsPageShotsQueryTitle = Shots by Day
+metricsPageShotsQueryDescription = Number of shots created each day (for the last 30 days)
+metricsPageShotsQueryCount = Number of shots
+metricsPageShotsQueryDay = Day
+metricsPageUsersQueryTitle = Users by Day
+metricsPageUsersQueryDescription = Number of users who created at least one shot, by day (last 30 days)
+metricsPageUsersQueryCount = Number of users
+metricsPageUsersQueryDay = Day
+metricsPageUserShotsQueryTitle = Number of Shots per User
+metricsPageUserShotsQueryDescription = The number of users who have about N total shots
+metricsPageUserShotsQueryCount = Number of users
+metricsPageUserShotsQueryShots = Approximate number of active (unexpired) shots
+metricsPageRetentionQueryTitle = Retention by Week
+metricsPageRetentionQueryDescription = Number of days from a userʼs first shot to most recent shot, grouped by starting week
+metricsPageRetentionQueryUsers = Number of users
+metricsPageRetentionQueryDays = Days from the userʼs first to most recent shot
+metricsPageRetentionQueryFirstWeek = Week the user first created a shot
+metricsPageTotalRetentionQueryTitle = Total Retention
+metricsPageTotalRetentionQueryDescription = Length of time users have been creating shots, grouped by week
+metricsPageTotalRetentionQueryUsers = Number of users
+metricsPageTotalRetentionQueryDays = Days the user has been creating shots
+metricsPageVersionQueryTitle = Add-on Version
+metricsPageVersionQueryDescription = The version of the add-on used during login, in the last 14 days
+metricsPageVersionQueryUsers = Number of users logging in
+metricsPageVersionQueryVersion = Add-on version
+metricsPageVersionQueryLastSeen = Day
+metricsPageHeader = Metrics
+// Note: { $created } is a placeholder for a localized date and time, like '4/21/2017, 3:40:04 AM'
+metricsPageGeneratedDateTime = Generated at: { $created }
+// Note { $time } is a placeholder for a number of milliseconds, like '100'
+metricsPageDatabaseQueryTime = (database time: { $time }ms)

--- a/locales/en-CA/webextension.properties
+++ b/locales/en-CA/webextension.properties
@@ -1,0 +1,83 @@
+# Clip in this context refers to a portion of an image
+addonDescription = Take clips and screenshots from the Web and save them temporarily or permanently.
+addonAuthorsList = Mozilla <screenshots-feedback@mozilla.com>
+# Also used for the title on the toolbar button
+contextMenuLabel = Take a Screenshot
+myShotsLink = My Shots
+screenshotInstructions = Drag or click on the page to select a region. Press ESC to cancel.
+saveScreenshotSelectedArea = Save
+saveScreenshotVisibleArea = Save visible
+saveScreenshotFullPage = Save full page
+cancelScreenshot = Cancel
+downloadScreenshot = Download
+downloadOnlyNotice = You are currently in Download-Only mode.
+# The downloadOnlyDetails string introduces a list of items. The keys
+# downloadOnlyDetailsPrivate, downloadOnlyDetailsThirdParty, and
+# downloadOnlyDetailsNeverRemember are list items in that list.
+downloadOnlyDetails = Firefox Screenshots automatically changes to Download-Only mode in these situations:
+downloadOnlyDetailsPrivate = In a Private Browsing window.
+downloadOnlyDetailsThirdParty = Third-party cookies are disabled.
+downloadOnlyDetailsNeverRemember = “Never remember history” is enabled.
+notificationLinkCopiedTitle = Link Copied
+# The string "{meta_key}-V" should be translated to the region-specific
+# shorthand for the Paste keyboard shortcut. {meta_key} is a placeholder for the
+# modifier key used in the shortcut (do not translate it): for example, Ctrl-V
+# on Windows systems.
+notificationLinkCopiedDetails = The link to your shot has been copied to the clipboard. Press {meta_key}-V to paste.
+# This is a verb, as in "Copy image to the system clipboard."
+copyScreenshot = Copy
+notificationImageCopiedTitle = Shot Copied
+# The string "{meta_key}-V" should be translated to the region-specific
+# shorthand for the Paste keyboard shortcut. {meta_key} is a placeholder for the
+# modifier key used in the shortcut (do not translate it): for example, Ctrl-V
+# on Windows systems.
+notificationImageCopiedDetails = Your shot has been copied to the clipboard. Press {meta_key}-V to paste.
+# This is displayed as a warning when a Full Page save will be cropped.
+# {pixels} will be a number like 5000.
+imageCroppedWarning = This image has been cropped to {pixels}px.
+# Section for error strings
+# "Out of order" is an humorous way to indicate that the service is not working
+# properly.
+requestErrorTitle = Out of order.
+requestErrorDetails = Sorry! We couldn’t save your shot. Please try again later.
+connectionErrorTitle = We can’t connect to your screenshots.
+connectionErrorDetails = Please check your Internet connection. If you are able to connect to the Internet, there may be a temporary problem with the Firefox Screenshots service.
+loginErrorDetails = We couldn’t save your shot because there is a problem with the Firefox Screenshots service. Please try again later.
+unshootablePageErrorTitle = We can’t screenshot this page.
+unshootablePageErrorDetails = This isn’t a standard Web page, so you can’t take a screenshot of it.
+selfScreenshotErrorTitle = You can’t take a shot of a Firefox Screenshots page!
+# Fired when someone makes a zero-width or zero-height selection
+emptySelectionErrorTitle = Your selection is too small
+privateWindowErrorTitle = Screenshots is disabled in Private Browsing Mode
+privateWindowErrorDetails = Sorry for the inconvenience. We are working on this feature for future releases.
+genericErrorTitle = Whoa! Firefox Screenshots went haywire.
+genericErrorDetails = We’re not sure what just happened. Care to try again or take a shot of a different page?
+# Section for onboarding strings
+# Slide number 1:
+tourBodyIntro = Take, save, and share screenshots without leaving Firefox.
+# Slide number 2:
+tourHeaderPageAction = A new way to save
+tourBodyPageAction = Expand the page actions menu in the address bar any time you want to take a screenshot.
+# Slide number 3:
+tourHeaderClickAndDrag = Capture Just What You Want
+tourBodyClickAndDrag = Click and drag to capture just a portion of a page. You can also hover to highlight your selection.
+# Slide number 4:
+tourHeaderFullPage = Capture Windows or Entire Pages
+tourBodyFullPage = Select the buttons in the upper right to capture the visible area in the window or to capture an entire page.
+# Slide number 5:
+tourHeaderDownloadUpload = As You Like It
+tourBodyDownloadUpload = Save your cropped shots to the web for easier sharing, or download them to your computer. You also can click on the My Shots button to find all the shots you’ve taken.
+tourSkip = SKIP
+tourNext = Next Slide
+tourPrevious = Previous Slide
+tourDone = Done
+# Do not translate {termsAndPrivacyNoticeTermsLink} and
+# {termsAndPrivacyNoticyPrivacyLink}. They're placeholders replaced by links
+# using the corresponding translated strings as text.
+termsAndPrivacyNotice2 = By using Firefox Screenshots, you agree to our {termsAndPrivacyNoticeTermsLink} and {termsAndPrivacyNoticePrivacyLink}.
+# This string is used as the text for a link in termsAndPrivacyNoticeCloudServices
+termsAndPrivacyNoticeTermsLink = Terms
+# This string is used as the text for a link in termsAndPrivacyNoticeCloudServices
+termsAndPrivacyNoticyPrivacyLink = Privacy Notice
+# This string is used to label the item in the Library panel that opens the screenshots page
+libraryLabel = Screenshots


### PR DESCRIPTION
We are starting to distribute en-CA localization, and using en-GB to boostrap it