### PR TITLE
Fix #4352, document pref required to install dev Screenshots on some profiles

### DIFF
--- a/static/homepage/install-test-local.html
+++ b/static/homepage/install-test-local.html
@@ -37,7 +37,7 @@
           <ul>
             <li><strong><code>xpinstall.signatures.required</code></strong> to <code>false</code></li>
             <li><strong><code>extensions.legacy.enabled</code></strong> to <code>true</code></li>
-            <li><strong><code>extensions.screenshots.system-disabled</code></strong> to <code>false</code> (<em>if</em> you see this preference, you might find it already removed)</li>
+            <li><strong><code>extensions.install.requireBuiltInCerts</code></strong> to <code>false</code></li>
           </ul>
         </li>
         <li>Click <a href="/xpi/screenshots.xpi">Install</a></li>


### PR DESCRIPTION
Also removes reference to extensions.screenshots.system-disabled which we no longer use