### PR TITLE
Fix #4147, Avoid including blank scrollbar area in save-visible shots

### DIFF
--- a/addon/webextension/selector/uicontrol.js
+++ b/addon/webextension/selector/uicontrol.js
@@ -186,7 +186,7 @@ this.uicontrol = (function() {
       sendEvent("capture-visible", "selection-button");
       selectedPos = new Selection(
         window.scrollX, window.scrollY,
-        window.scrollX + window.innerWidth, window.scrollY + window.innerHeight);
+        window.scrollX + document.documentElement.clientWidth, window.scrollY + window.innerHeight);
       captureType = "visible";
       setState("previewing");
     },


### PR DESCRIPTION
`document.documentElement.clientWidth` seems to be more reliable than `window.innerWidth` for dealing with scrollbars on both windows and osx. I'm not sure what other edge cases might be broken by this change, though :-P

For more discussion, see: https://tylercipriani.com/blog/2014/07/12/crossbrowser-javascript-scrollbar-detection/