### PR TITLE
Enable FxA via user settings menu

### DIFF
--- a/server/src/config.js
+++ b/server/src/config.js
@@ -329,7 +329,7 @@ const conf = convict({
   enableUserSettings: {
     doc: "If true, the user can see the settings page and connect their device to their firefox account",
     format: Boolean,
-    default: false,
+    default: true,
     env: "USER_SETTINGS",
     arg: "user-settings"
   },


### PR DESCRIPTION
I don't see the gear menu in 'my shots' on stage. Looks like we need to flip a config value to enable it; seems reasonable to just flip the default.