### PR TITLE
Fix #4459, include meta robots noindex in all shot pages

### DIFF
--- a/server/src/pages/shot/view.js
+++ b/server/src/pages/shot/view.js
@@ -91,7 +91,7 @@ class Head extends React.Component {
     if (expired) {
       return (
         <reactruntime.HeadTemplate {...this.props}>
-          <meta name="robots" content="noindex" />
+          <meta name="robots" content="noindex, nofollow, noimageindex" />
           <script src={ this.props.staticLink("/static/js/wantsauth.js") } />
           <script src={ this.props.staticLink("/static/js/shot-bundle.js") } async />
           <link rel="stylesheet" href={ this.props.staticLink("/static/css/frame.css") } />
@@ -102,6 +102,7 @@ class Head extends React.Component {
     // FIXME: we need to review if the oembed form actually works and is valuable (#585)
     return (
       <reactruntime.HeadTemplate {...this.props}>
+        <meta name="robots" content="noindex, nofollow, noimageindex" />
         <script src={ this.props.staticLink("/static/js/wantsauth.js") } />
         <script src={ this.props.staticLink("/static/js/shot-bundle.js") } async />
         <link rel="stylesheet" href={ this.props.staticLink("/static/css/inline-selection.css") } />


### PR DESCRIPTION
This was intended to be fixed in #2806, but was only put in place for expired pages instead of all pages as intended.