### PR TITLE
Fixes #4467 - Filter out download canceled error messages in logs

### DIFF
--- a/addon/webextension/background/main.js
+++ b/addon/webextension/background/main.js
@@ -265,8 +265,11 @@ this.main = (function() {
         url,
         incognito: windowInfo.incognito,
         filename: info.filename
-      }).catch(function(error) {
-        log.error(error.message);
+      }).catch((error) => {
+        // We are not logging error message when user cancels download
+        if (error && error.message && !error.message.includes("canceled")) {
+          log.error(error.message);
+        }
       }).then((id) => {
         downloadId = id;
       });


### PR DESCRIPTION
Slight follow up fix to #3964 PR to filter out download canceled in error logs