### PR TITLE
Allow bin/run-addon to discover Firefoxes with spaces in the app name

### DIFF
--- a/bin/run-addon
+++ b/bin/run-addon
@@ -11,7 +11,9 @@ nodemon_pid=
 binary=
 firefoxes="
 /Applications/FirefoxNightly.app
+/Applications/Firefox\ Nightly.app
 /Applications/FirefoxDeveloperEdition.app
+/Applications/Firefox\ Developer\ Edition.app
 /Applications/FirefoxAurora.app
 $(which firefox || true)
 "


### PR DESCRIPTION
Refs bug 1404796.