### PR TITLE
Delete any locale messages.json that match the en_US/messages.json file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,9 @@ signed_xpi: addon
 .PHONY: addon_locales
 addon_locales:
 	./node_modules/.bin/pontoon-to-webext --dest addon/webextension/_locales > /dev/null
+	# Firefox doesn't want us to include duplicate files, and some locales don't have any
+	# unique strings compared to en_US:
+	./bin/build-scripts/delete-us-dup-locales.sh
 
 addon/install.rdf: addon/install.rdf.template package.json
 	./bin/build-scripts/update_manifest.py $< $@

--- a/bin/build-scripts/delete-us-dup-locales.sh
+++ b/bin/build-scripts/delete-us-dup-locales.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+
+locales=addon/webextension/_locales
+us_locale=addon/webextension/_locales/en_US/messages.json
+us_locale_content="$(cat $us_locale)"
+
+for other_locale in $locales/*/messages.json ; do
+  if [[ "$other_locale" = "$us_locale" ]] ; then
+    continue
+  fi
+  other_locale_content="$(cat $other_locale)"
+  if [[ "$other_locale_content" = "$us_locale_content" ]] ; then
+    echo "Deleting duplicate locale $other_locale"
+    rm $other_locale
+  fi
+done


### PR DESCRIPTION
This keeps us from adding duplicate files to Firefox. Specifically en_CA has no differences from en_US