### PR TITLE
Remove redundant pageAction.setIcon calls from onboarding

### DIFF
--- a/addon/webextension/background/main.js
+++ b/addon/webextension/background/main.js
@@ -13,9 +13,6 @@ this.main = (function() {
 
   let hasSeenOnboarding = browser.storage.local.get(["hasSeenOnboarding"]).then((result) => {
     const onboarded = !!result.hasSeenOnboarding;
-    if (!onboarded) {
-      setIconActive(false, null);
-    }
     hasSeenOnboarding = Promise.resolve(onboarded);
     return hasSeenOnboarding;
   }).catch((error) => {
@@ -283,7 +280,6 @@ this.main = (function() {
   communication.register("hasSeenOnboarding", () => {
     hasSeenOnboarding = Promise.resolve(true);
     catcher.watchPromise(browser.storage.local.set({hasSeenOnboarding: true}));
-    setIconActive(false, null);
   });
 
   communication.register("abortStartShot", () => {


### PR DESCRIPTION
hen we changed from a Photon pageAction to a WebExtension pageAction, there were a couple spots left over where the pageAction's icon was toggled, but the tab ID wasn't passed in. This was originally necessary because we had a `#tour` (or maybe `#hello`?) endpoint at the screenshots website, where we'd open the onboarding flow automatically.

With the move to the webextension pageAction, the https://screenshots.firefox.com/#tour page now just opens the doorhanger and invites the user to click the menu item:

<img width="490" alt="screen shot 2018-07-02 at 1 58 36 pm" src="https://user-images.githubusercontent.com/96396/42186079-178bfab8-7e00-11e8-8186-303119d264a7.png">

I can't find any way to trigger onboarding other than clicking the page action or context menu item, and those clicks already correctly toggle the icon state. So, we're good to remove those extra setIcon calls.