### PR TITLE
Return both DB and JS patch levels in __version__

### DIFF
--- a/server/src/dbschema.js
+++ b/server/src/dbschema.js
@@ -166,6 +166,7 @@ function getCurrentDbPatchLevel() {
     return 0;
   });
 }
+exports.getCurrentDbPatchLevel = getCurrentDbPatchLevel;
 
 exports.connectionOK = function() {
   if (!keys) {

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -959,19 +959,24 @@ app.get("/images/:imageid", function(req, res) {
 });
 
 app.get("/__version__", function(req, res) {
-  const response = {
-    source: "https://github.com/mozilla-services/screenshots/",
-    description: "Firefox Screenshots application server",
-    version: selfPackage.version,
-    buildDate: buildTime,
-    commit: linker.getGitRevision(),
-    contentOrigin: config.contentOrigin,
-    commitLog: `https://github.com/mozilla-services/screenshots/commits/${linker.getGitRevision()}`,
-    unincludedCommits: `https://github.com/mozilla-services/screenshots/compare/${linker.getGitRevision()}...master`,
-    dbSchemaVersion: dbschema.MAX_DB_LEVEL
-  };
-  res.header("Content-Type", "application/json; charset=utf-8");
-  res.send(JSON.stringify(response, null, "  "));
+  dbschema.getCurrentDbPatchLevel().then(level => {
+    const response = {
+      source: "https://github.com/mozilla-services/screenshots/",
+      description: "Firefox Screenshots application server",
+      version: selfPackage.version,
+      buildDate: buildTime,
+      commit: linker.getGitRevision(),
+      contentOrigin: config.contentOrigin,
+      commitLog: `https://github.com/mozilla-services/screenshots/commits/${linker.getGitRevision()}`,
+      unincludedCommits: `https://github.com/mozilla-services/screenshots/compare/${linker.getGitRevision()}...master`,
+      dbSchemaVersion: level,
+      dbSchemaVersionJS: dbschema.MAX_DB_LEVEL
+    };
+    res.header("Content-Type", "application/json; charset=utf-8");
+    res.send(JSON.stringify(response, null, "  "));
+  }).catch((e) => {
+    errorResponse(res, "Error fetching version data: ", e);
+  });
 });
 
 app.get("/contribute.json", function(req, res) {


### PR DESCRIPTION
Now that we have potential divergence between the patch level in the code and the patch level in the database, it seems useful to report both values in the `__version__` endpoint. So, `dbSchemaVersion` is now the patch level in the database, and `dbSchemaVersionJS` is the patch level in the server code.

Fixes #4569.