### PR TITLE
Fix #4603, Add permissions to enable PDF.js and reader mode shots

### DIFF
--- a/addon/webextension/manifest.json.template
+++ b/addon/webextension/manifest.json.template
@@ -71,6 +71,8 @@
     "contextMenus",
     "mozillaAddons",
     "<all_urls>",
-    "http://localhost:10080/"
+    "http://localhost:10080/",
+    "resource://pdf.js/",
+    "about:reader*"
   ]
 }


### PR DESCRIPTION
The relevant permissions were added directly to mozilla-central in bug 1466349.