### PR TITLE
Replace Telemetry bootstrap code with Telemetry API

### DIFF
--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -184,14 +184,5 @@ function handleMessage(msg, sender, sendReply) {
   } else if (msg.funcName === "isHistoryEnabled") {
     const historyEnabled = getBoolPref(HISTORY_ENABLED_PREF);
     sendReply({type: "success", value: historyEnabled});
-  } else if (msg.funcName === "incrementCount") {
-    const allowedScalars = ["download", "upload", "copy"];
-    const scalar = msg.args && msg.args[0] && msg.args[0].scalar;
-    if (!allowedScalars.includes(scalar)) {
-      sendReply({type: "error", name: `incrementCount passed an unrecognized scalar ${scalar}`});
-    } else {
-      Services.telemetry.scalarAdd(`screenshots.${scalar}`, 1);
-      sendReply({type: "success", value: true});
-    }
   }
 }

--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -1,6 +1,5 @@
 /* globals ADDON_DISABLE Services CustomizableUI LegacyExtensionsUtils AppConstants PageActions */
 const ADDON_ID = "screenshots@mozilla.org";
-const TELEMETRY_ENABLED_PREF = "datareporting.healthreport.uploadEnabled";
 const PREF_BRANCH = "extensions.screenshots.";
 const USER_DISABLE_PREF = "extensions.screenshots.disabled";
 const UPLOAD_DISABLED_PREF = "extensions.screenshots.upload-disabled";
@@ -178,10 +177,7 @@ function handleMessage(msg, sender, sendReply) {
     return;
   }
 
-  if (msg.funcName === "isTelemetryEnabled") {
-    const telemetryEnabled = getBoolPref(TELEMETRY_ENABLED_PREF);
-    sendReply({type: "success", value: telemetryEnabled});
-  } else if (msg.funcName === "isUploadDisabled") {
+  if (msg.funcName === "isUploadDisabled") {
     const isESR = AppConstants.MOZ_UPDATE_CHANNEL === "esr";
     const uploadDisabled = getBoolPref(UPLOAD_DISABLED_PREF);
     sendReply({type: "success", value: uploadDisabled || isESR});

--- a/addon/webextension/background/analytics.js
+++ b/addon/webextension/background/analytics.js
@@ -1,4 +1,4 @@
-/* globals main, auth, catcher, deviceInfo, communication, log */
+/* globals main, auth, browser, catcher, deviceInfo, communication, log */
 
 "use strict";
 
@@ -129,13 +129,9 @@ this.analytics = (function() {
   };
 
   exports.refreshTelemetryPref = function() {
-    return communication.sendToBootstrap("isTelemetryEnabled").then((result) => {
+    return browser.telemetry.canUpload().then((result) => {
       telemetryPrefKnown = true;
-      if (result === communication.NO_BOOTSTRAP) {
-        telemetryEnabled = true;
-      } else {
-        telemetryEnabled = result;
-      }
+      telemetryEnabled = result;
     }, (error) => {
       // If there's an error reading the pref, we should assume that we shouldn't send data
       telemetryPrefKnown = true;

--- a/addon/webextension/background/analytics.js
+++ b/addon/webextension/background/analytics.js
@@ -128,6 +128,18 @@ this.analytics = (function() {
     return Promise.resolve();
   };
 
+  exports.incrementCount = function(scalar) {
+    const allowedScalars = ["download", "upload", "copy"];
+    if (!allowedScalars.includes(scalar)) {
+      const err = `incrementCount passed an unrecognized scalar ${scalar}`;
+      log.warn(err);
+      return Promise.resolve();
+    }
+    return browser.telemetry.scalarAdd(`screenshots.${scalar}`, 1).catch(err => {
+      log.warn(`incrementCount failed with error: ${err}`);
+    });
+  };
+
   exports.refreshTelemetryPref = function() {
     return browser.telemetry.canUpload().then((result) => {
       telemetryPrefKnown = true;

--- a/addon/webextension/background/main.js
+++ b/addon/webextension/background/main.js
@@ -6,7 +6,7 @@ this.main = (function() {
   const exports = {};
 
   const pasteSymbol = (window.navigator.platform.match(/Mac/i)) ? "\u2318" : "Ctrl";
-  const { sendEvent } = analytics;
+  const { sendEvent, incrementCount } = analytics;
 
   const manifest = browser.runtime.getManifest();
   let backend;
@@ -229,7 +229,7 @@ this.main = (function() {
     return blobConverters.blobToArray(blob).then(buffer => {
       return browser.clipboard.setImageData(
         buffer, blob.type.split("/", 2)[1]).then(() => {
-          catcher.watchPromise(communication.sendToBootstrap("incrementCount", {scalar: "copy"}));
+          catcher.watchPromise(incrementCount("copy"));
           return browser.notifications.create({
             type: "basic",
             iconUrl: "../icons/copied-notification.svg",
@@ -256,7 +256,7 @@ this.main = (function() {
       }
     });
     browser.downloads.onChanged.addListener(onChangedCallback);
-    catcher.watchPromise(communication.sendToBootstrap("incrementCount", {scalar: "download"}));
+    catcher.watchPromise(incrementCount("download"));
     return browser.windows.getLastFocused().then(windowInfo => {
       return browser.downloads.download({
         url,

--- a/addon/webextension/background/takeshot.js
+++ b/addon/webextension/background/takeshot.js
@@ -5,7 +5,7 @@
 this.takeshot = (function() {
   const exports = {};
   const Shot = shot.AbstractShot;
-  const { sendEvent } = analytics;
+  const { sendEvent, incrementCount } = analytics;
 
   communication.register("takeShot", catcher.watchFunction((sender, options) => {
     const { captureType, captureText, scroll, selectedPos, shotId } = options;
@@ -76,7 +76,7 @@ this.takeshot = (function() {
         }
       );
     }).then(() => {
-      catcher.watchPromise(communication.sendToBootstrap("incrementCount", {scalar: "upload"}));
+      catcher.watchPromise(incrementCount("upload"));
       return shot.viewUrl;
     }).catch((error) => {
       browser.tabs.remove(openedTab.id);

--- a/addon/webextension/manifest.json.template
+++ b/addon/webextension/manifest.json.template
@@ -70,6 +70,7 @@
     "clipboardWrite",
     "contextMenus",
     "mozillaAddons",
+    "telemetry",
     "<all_urls>",
     "http://localhost:10080/",
     "resource://pdf.js/",


### PR DESCRIPTION
Fixes #3713.

First commit removes the bootstrap check of the Telemetry enabled pref. That pref is now checked by calling the `browser.telemetry.canUpload()` API.

Second commit removes the bootstrap code that emits `Services.telemetry.scalarAdd()` calls to increment counts when shots are downloaded, copied, or uploaded. This is replaced by the `browser.telemetry.scalarAdd()` API.

These APIs are currently only available on Nightly.