### PR TITLE
Move the ESR check from bootstrap into webextension API

### DIFF
--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -1,4 +1,4 @@
-/* globals ADDON_DISABLE Services CustomizableUI LegacyExtensionsUtils AppConstants PageActions */
+/* globals ADDON_DISABLE Services CustomizableUI LegacyExtensionsUtils PageActions */
 const ADDON_ID = "screenshots@mozilla.org";
 const PREF_BRANCH = "extensions.screenshots.";
 const USER_DISABLE_PREF = "extensions.screenshots.disabled";
@@ -8,8 +8,6 @@ const HISTORY_ENABLED_PREF = "places.history.enabled";
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.defineModuleGetter(this, "AddonManager",
                                "resource://gre/modules/AddonManager.jsm");
-ChromeUtils.defineModuleGetter(this, "AppConstants",
-                               "resource://gre/modules/AppConstants.jsm");
 ChromeUtils.defineModuleGetter(this, "CustomizableUI",
                                "resource:///modules/CustomizableUI.jsm");
 ChromeUtils.defineModuleGetter(this, "LegacyExtensionsUtils",
@@ -178,9 +176,8 @@ function handleMessage(msg, sender, sendReply) {
   }
 
   if (msg.funcName === "isUploadDisabled") {
-    const isESR = AppConstants.MOZ_UPDATE_CHANNEL === "esr";
     const uploadDisabled = getBoolPref(UPLOAD_DISABLED_PREF);
-    sendReply({type: "success", value: uploadDisabled || isESR});
+    sendReply({type: "success", value: uploadDisabled});
   } else if (msg.funcName === "isHistoryEnabled") {
     const historyEnabled = getBoolPref(HISTORY_ENABLED_PREF);
     sendReply({type: "success", value: historyEnabled});

--- a/addon/webextension/background/selectorLoader.js
+++ b/addon/webextension/background/selectorLoader.js
@@ -94,14 +94,16 @@ this.selectorLoader = (function() {
   function downloadOnlyCheck(tabId) {
     return communication.sendToBootstrap("isHistoryEnabled").then((historyEnabled) => {
       return communication.sendToBootstrap("isUploadDisabled").then((uploadDisabled) => {
-        return browser.tabs.get(tabId).then(tab => {
-          const downloadOnly = !historyEnabled || uploadDisabled || tab.incognito;
-          return browser.tabs.executeScript(tabId, {
-            // Note: `window` here refers to a global accessible to content
-            // scripts, but not the scripts in the underlying page. For more
-            // details, see https://mdn.io/WebExtensions/Content_scripts#Content_script_environment
-            code: `window.downloadOnly = ${downloadOnly}`,
-            runAt: "document_start"
+        return browser.experiments.screenshots.getUpdateChannel().then((channel) => {
+          return browser.tabs.get(tabId).then(tab => {
+            const downloadOnly = !historyEnabled || uploadDisabled || channel === "esr" || tab.incognito;
+            return browser.tabs.executeScript(tabId, {
+              // Note: `window` here refers to a global accessible to content
+              // scripts, but not the scripts in the underlying page. For more
+              // details, see https://mdn.io/WebExtensions/Content_scripts#Content_script_environment
+              code: `window.downloadOnly = ${downloadOnly}`,
+              runAt: "document_start"
+            });
           });
         });
       });

--- a/addon/webextension/experiments/screenshots/api.js
+++ b/addon/webextension/experiments/screenshots/api.js
@@ -1,0 +1,34 @@
+/* globals AppConstants, ExtensionAPI */
+
+"use strict";
+
+ChromeUtils.defineModuleGetter(this, "AppConstants",
+                               "resource://gre/modules/AppConstants.jsm");
+
+this.screenshots = class extends ExtensionAPI {
+  getAPI() {
+    return {
+      experiments: {
+        screenshots: {
+          // If you are checking for 'nightly', also check for 'nightly-try'.
+          //
+          // Otherwise, just use the standard builds, but be aware of the many
+          // non-standard options that also exist (as of August 2018).
+          //
+          // Standard builds:
+          //   'esr' - ESR channel
+          //   'release' - release channel
+          //   'beta' - beta channel
+          //   'nightly' - nightly channel
+          // Non-standard / deprecated builds:
+          //   'aurora' - deprecated aurora channel (still observed in dxr)
+          //   'default' - local builds from source
+          //   'nightly-try' - nightly Try builds (QA may occasionally need to test with these)
+          async getUpdateChannel() {
+            return AppConstants.MOZ_UPDATE_CHANNEL;
+          },
+        },
+      },
+    };
+  }
+};

--- a/addon/webextension/experiments/screenshots/schema.json
+++ b/addon/webextension/experiments/screenshots/schema.json
@@ -1,0 +1,15 @@
+[
+  {
+    "namespace": "experiments.screenshots",
+    "description": "Firefox Screenshots internal API",
+    "functions": [
+      {
+        "name": "getUpdateChannel",
+        "type": "function",
+        "description": "Returns the Firefox channel (AppConstants.MOZ_UPDATE_CHANNEL)",
+        "parameters": [],
+        "async": true
+      }
+    ]
+  }
+]

--- a/addon/webextension/manifest.json.template
+++ b/addon/webextension/manifest.json.template
@@ -75,5 +75,15 @@
     "http://localhost:10080/",
     "resource://pdf.js/",
     "about:reader*"
-  ]
+  ],
+  "experiment_apis": {
+    "screenshots": {
+      "schema": "experiments/screenshots/schema.json",
+      "parent": {
+        "scopes": ["addon_parent"],
+        "script": "experiments/screenshots/api.js",
+        "paths": [["experiments", "screenshots"]]
+      }
+    }
+  }
 }


### PR DESCRIPTION
Fixes #4802.

* Add a webextension experiment API to Screenshots that exposes app update channel
* Move ESR check from bootstrap to webextension API

Unfortunately, ESR 60 doesn't allow legacy extensions, so there's no way to test this works in that case. But you can set the debugger and see that it returns the correct channel if you test from nightly :-\