### PR TITLE
Check some prefs from the API, not from bootstrap

### DIFF
--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -2,8 +2,6 @@
 const ADDON_ID = "screenshots@mozilla.org";
 const PREF_BRANCH = "extensions.screenshots.";
 const USER_DISABLE_PREF = "extensions.screenshots.disabled";
-const UPLOAD_DISABLED_PREF = "extensions.screenshots.upload-disabled";
-const HISTORY_ENABLED_PREF = "places.history.enabled";
 
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.defineModuleGetter(this, "AddonManager",
@@ -150,7 +148,6 @@ function handleStartup() {
 
 function start(webExtension) {
   return webExtension.startup(startupReason, addonData).then((api) => {
-    api.browser.runtime.onMessage.addListener(handleMessage);
     LibraryButton.init(webExtension);
   }).catch((err) => {
     // The startup() promise will be rejected if the webExtension was
@@ -168,18 +165,4 @@ function stop(webExtension, reason) {
     LibraryButton.uninit();
   }
   return Promise.resolve(webExtension.shutdown(reason));
-}
-
-function handleMessage(msg, sender, sendReply) {
-  if (!msg) {
-    return;
-  }
-
-  if (msg.funcName === "isUploadDisabled") {
-    const uploadDisabled = getBoolPref(UPLOAD_DISABLED_PREF);
-    sendReply({type: "success", value: uploadDisabled});
-  } else if (msg.funcName === "isHistoryEnabled") {
-    const historyEnabled = getBoolPref(HISTORY_ENABLED_PREF);
-    sendReply({type: "success", value: historyEnabled});
-  }
 }

--- a/addon/webextension/background/selectorLoader.js
+++ b/addon/webextension/background/selectorLoader.js
@@ -92,8 +92,8 @@ this.selectorLoader = (function() {
   // TODO: since bootstrap communication is now required, would this function
   // make more sense inside background/main?
   function downloadOnlyCheck(tabId) {
-    return communication.sendToBootstrap("isHistoryEnabled").then((historyEnabled) => {
-      return communication.sendToBootstrap("isUploadDisabled").then((uploadDisabled) => {
+    return browser.experiments.screenshots.isHistoryEnabled().then((historyEnabled) => {
+      return browser.experiments.screenshots.isUploadDisabled().then((uploadDisabled) => {
         return browser.experiments.screenshots.getUpdateChannel().then((channel) => {
           return browser.tabs.get(tabId).then(tab => {
             const downloadOnly = !historyEnabled || uploadDisabled || channel === "esr" || tab.incognito;

--- a/addon/webextension/experiments/screenshots/api.js
+++ b/addon/webextension/experiments/screenshots/api.js
@@ -4,6 +4,8 @@
 
 ChromeUtils.defineModuleGetter(this, "AppConstants",
                                "resource://gre/modules/AppConstants.jsm");
+ChromeUtils.defineModuleGetter(this, "Services",
+                               "resource://gre/modules/Services.jsm");
 
 this.screenshots = class extends ExtensionAPI {
   getAPI() {
@@ -24,8 +26,14 @@ this.screenshots = class extends ExtensionAPI {
           //   'aurora' - deprecated aurora channel (still observed in dxr)
           //   'default' - local builds from source
           //   'nightly-try' - nightly Try builds (QA may occasionally need to test with these)
-          async getUpdateChannel() {
+          getUpdateChannel() {
             return AppConstants.MOZ_UPDATE_CHANNEL;
+          },
+          isHistoryEnabled() {
+            return Services.prefs.getBoolPref("places.history.enabled", true);
+          },
+          isUploadDisabled() {
+            return Services.prefs.getBoolPref("extensions.screenshots.upload-disabled", false);
           },
         },
       },

--- a/addon/webextension/experiments/screenshots/schema.json
+++ b/addon/webextension/experiments/screenshots/schema.json
@@ -9,6 +9,20 @@
         "description": "Returns the Firefox channel (AppConstants.MOZ_UPDATE_CHANNEL)",
         "parameters": [],
         "async": true
+      },
+      {
+        "name": "isHistoryEnabled",
+        "type": "function",
+        "description": "Returns the value of the 'places.history.enabled' preference",
+        "parameters": [],
+        "async": true
+      },
+      {
+        "name": "isUploadDisabled",
+        "type": "function",
+        "description": "Returns the value of the 'extensions.screenshots.upload-disabled' preference",
+        "parameters": [],
+        "async": true
       }
     ]
   }


### PR DESCRIPTION
Move the history enabled and upload-disabled checks from bootstrap into the API.

It might make sense to just check all the prefs in a single API call, but this works for now.

This commit fixes #4531, and depends on the two commits from PR #4809.