### PR TITLE
Mark a shot as OpenGraph "image" type

### DIFF
--- a/server/src/pages/shot/view.js
+++ b/server/src/pages/shot/view.js
@@ -119,7 +119,7 @@ class Head extends React.Component {
       return null;
     }
     const og = [
-      <meta property="og:type" content="website" key="ogtype" />,
+      <meta property="og:type" content="image" key="ogtype" />,
       <meta property="og:title" content={this.props.shot.title} key="ogtitle" />
     ];
     const twitter = [


### PR DESCRIPTION
When the URL is copy and pasted onto its own line in a [discourse.org](https://discourse.org) forum, the preview looks like this:

[![](https://screenshotscdn.firefoxusercontent.com/images/65241f16-f327-4f8f-a79e-a581088874eb.png)](https://screenshots.firefox.com/p2rtWjzO6zbC7JNf/forum.bors.tech)

If the OpenGraph type is set to "image", it'll actually embed the image directly without any of the superflouous title stuff, the same way it does for other image hosts like imgur.