### PR TITLE
Update Footer

### DIFF
--- a/server/src/footer-view.js
+++ b/server/src/footer-view.js
@@ -10,37 +10,37 @@ exports.Footer = class Footer extends React.Component {
 
   render() {
     return (
-      <div className="footer">
+      <footer className="footer">
         <a href="https://www.mozilla.org" target="_blank" rel="noopener noreferrer" className="mozilla-logo" title="Mozilla"/>
-        <div className="legal-links">
-          <Localized id="footerLinkTerms">
+        <ul className="footer-links">
+          <li><Localized id="footerLinkTerms">
             <a href="https://www.mozilla.org/about/legal/terms/services/" target="_blank" rel="noopener noreferrer">Terms</a>
-          </Localized>
-          <Localized id="footerLinkPrivacy">
+          </Localized></li>
+          <li><Localized id="footerLinkPrivacy">
             <a href="https://www.mozilla.org/privacy/firefox/" target="_blank" rel="noopener noreferrer">Privacy Notice</a>
-          </Localized>
-          <Localized id="footerLinkFaqs">
+          </Localized></li>
+          <li><Localized id="footerLinkFaqs">
             <a href="https://support.mozilla.org/kb/firefox-screenshots" target="_blank" rel="noopener noreferrer">FAQs</a>
-          </Localized>
+          </Localized></li>
           {
             this.props.isOwner ? null
-            : <Localized id="footerReportShot">
+            : <li><Localized id="footerReportShot">
                 <a href={`https://qsurvey.mozilla.com/s3/screenshots-flagged-shots?ref=${this.props.id}`}
                   title="Report this shot for abuse, spam, or other problems"
                   target="_blank" rel="noopener noreferrer"
                   onClick={this.onReportShot.bind(this)}>Report Shot</a>
-              </Localized>
+              </Localized></li>
           }
-          <Localized id="footerLinkDMCA">
+          <li><Localized id="footerLinkDMCA">
             <a href="https://www.mozilla.org/about/legal/report-infringement/" target="_blank" rel="noopener noreferrer">Report IP Infringement</a>
-          </Localized>
-          <Localized id="footerLinkDiscourse">
+          </Localized></li>
+          <li><Localized id="footerLinkDiscourse">
             <a href="https://discourse.mozilla-community.org/c/test-pilot/page-shot" target="_blank" rel="noopener noreferrer">Give Feedback</a>
-          </Localized>
-          <a href="https://github.com/mozilla-services/screenshots" target="_blank" rel="noopener noreferrer">GitHub</a>
-          {this.props.authenticated ? <Localized id="footerLinkRemoveAllData"><a href="/leave-screenshots">Remove All Data</a></Localized> : null}
-        </div>
-      </div>
+          </Localized></li>
+          <li><a href="https://github.com/mozilla-services/screenshots" target="_blank" rel="noopener noreferrer">GitHub</a></li>
+          {this.props.isOwner ? <li><Localized id="footerLinkRemoveAllData"><a href="/leave-screenshots">Remove All Data</a></Localized></li> : null}
+        </ul>
+      </footer>
     );
   }
 };
@@ -48,5 +48,4 @@ exports.Footer = class Footer extends React.Component {
 exports.Footer.propTypes = {
   id: PropTypes.string,
   isOwner: PropTypes.bool,
-  authenticated: PropTypes.bool,
 };

--- a/static/css/inline-selection.scss
+++ b/static/css/inline-selection.scss
@@ -203,7 +203,7 @@ $very-light-grey: #ededed;
 
   .notice-wrapper {
     align-items: center;
-    background: #737373;
+    background: $gray;
     border-radius: 100px;
     display: flex;
     flex-wrap: nowrap;

--- a/static/css/partials/_footer.scss
+++ b/static/css/partials/_footer.scss
@@ -6,27 +6,20 @@
   @include flex-container(row, space-between, center);
   padding: $grid-unit * 1.5;
 
-
-
-  a {
-    font-size: $grid-unit * 0.75;
-  }
-
-  .legal-links {
+  .footer-links {
+    display: flex;
+    list-style: none;
+    margin: 0 0;
+    padding: 0 0;
 
     @include respond-to("small") {
       @include flex-container(column, space-between, stretch);
     }
-  }
 
-  .legal-links a {
-
-    @include respond-to("small") {
-      margin-top: $grid-unit * 0.25;
+    li {
+      font-size: 14px;
+      margin-right: 16px;
     }
-
-    font-size: 12px;
-    margin-right: $grid-unit * 0.75;
   }
 
   .mozilla-logo {

--- a/static/css/partials/_variables.scss
+++ b/static/css/partials/_variables.scss
@@ -4,6 +4,7 @@
 // UTILIY COLORS
 $black: #000;
 $white: #fff;
+$gray: #737373;
 
 // THEME COLORS
 $dark-default: #38383d;

--- a/static/css/settings.scss
+++ b/static/css/settings.scss
@@ -101,7 +101,7 @@
   }
 
   .sub-info {
-    color: #737373;
+    color: $gray;
     font-size: 13px;
     max-width: 400px;
     margin-top: 15px;


### PR DESCRIPTION
Fixes #4846 

This patch updates the markup and styles and fixes a bug where the "Remove All Data" is displayed to all non-owners (see https://github.com/mozilla-services/screenshots/issues/4846#issuecomment-420085982).

The color of the links are _not_ updated with this patch.  Link colors are theme specific; let's update those when we update other colors as well.