### PR TITLE
Fix #4893, make top border of "Edit shot title" box visible

### DIFF
--- a/static/css/frame.scss
+++ b/static/css/frame.scss
@@ -43,6 +43,7 @@
   @include respond-to("medium") {
     @include flex-container(row, flex-start, center);
     margin-right: 10px;
+    padding-top: 4px;
     overflow: hidden;
   }
 


### PR DESCRIPTION
Fix #4893