### PR TITLE
update color schemes on shot view and shot index view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@ cookie-jar.txt
 /webextension/manifest.json
 /webextension/_locales
 /*.xpi
+.vscode
 # Created by py.test:
 /test/server/.cache

--- a/server/src/header.js
+++ b/server/src/header.js
@@ -12,7 +12,7 @@ exports.Header = function Header(props) {
 
   return [
     <AdBanner key="banner" isOwner={props.isOwner} hasFxa={props.hasFxa} shouldGetFirefox={props.shouldGetFirefox} />,
-    <header key="header" className="header-panel default-color-scheme">
+    <header key="header" className="header-panel">
       {logo}
       {props.children}
     </header>,

--- a/server/src/pages/creating/view.js
+++ b/server/src/pages/creating/view.js
@@ -24,7 +24,7 @@ class Body extends React.Component {
   render() {
     return (
       <reactruntime.BodyTemplate {...this.props}>
-        <div className="column-center full-height inverse-color-scheme">
+        <div className="column-center full-height">
           <div className="loader">
             <div className="loader-inner" />
           </div>

--- a/server/src/pages/homepage/view.js
+++ b/server/src/pages/homepage/view.js
@@ -15,25 +15,25 @@ class Head extends React.Component {
   render() {
     return (
       <reactruntime.HeadTemplate {...this.props}>
-        <link rel="stylesheet" href={ this.props.staticLink("/static/css/home.css") } />
+        <link rel="stylesheet" href={this.props.staticLink("/static/css/home.css")} />
         <script src={this.props.staticLink("/static/js/UITour-lib.js")} async></script>
         <script src={this.props.staticLink("/static/js/homepage-bundle.js")} async></script>
         <meta name="viewport" content="width=320, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
         <Localized id="homePageDescription">
           <meta name="description" content="Intuitive screenshots baked right into the browser. Capture, save and share screenshots as you browse the Web using Firefox." />
         </Localized>
-        <meta property="og:title" content={ this.props.title } />
-        <meta property="og:url" content={ this.props.backend } />
+        <meta property="og:title" content={this.props.title} />
+        <meta property="og:url" content={this.props.backend} />
         <Localized id="homePageDescription">
           <meta property="og:description" content="Intuitive screenshots baked right into the browser. Capture, save and share screenshots as you browse the Web using Firefox." />
         </Localized>
-        <meta name="twitter:title" content={ this.props.title } />
+        <meta name="twitter:title" content={this.props.title} />
         <Localized id="homePageDescription">
           <meta name="twitter:description" content="Intuitive screenshots baked right into the browser. Capture, save and share screenshots as you browse the Web using Firefox." />
         </Localized>
         <meta name="twitter:card" content="summary" />
         <meta name="twitter:site" content="@firefox" />
-        <meta property="og:image" content={ this.props.staticLink("/static/img/og-image.png") } />
+        <meta property="og:image" content={this.props.staticLink("/static/img/og-image.png")} />
         <meta name="twitter:image" content={this.generateFullLink("/static/img/twitter-image.png")} />
       </reactruntime.HeadTemplate>
     );
@@ -49,7 +49,7 @@ Head.propTypes = {
 
 class Body extends React.Component {
   onClickInstallFirefox() {
-    sendEvent("click-install-firefox-home", {useBeacon: true});
+    sendEvent("click-install-firefox-home", { useBeacon: true });
   }
 
   renderGetFirefox() {
@@ -57,7 +57,7 @@ class Body extends React.Component {
       return null;
     }
     return (
-      <a href="https://www.mozilla.org/firefox/new/?utm_source=screenshots.firefox.com&utm_medium=referral&utm_campaign=screenshots-acquisition&utm_content=from-home" className="button primary download-firefox" onClick={ this.onClickInstallFirefox.bind(this) }>
+      <a href="https://www.mozilla.org/firefox/new/?utm_source=screenshots.firefox.com&utm_medium=referral&utm_campaign=screenshots-acquisition&utm_content=from-home" className="button primary download-firefox" onClick={this.onClickInstallFirefox.bind(this)}>
         <div className="button-icon">
           <div className="button-icon-badge"></div>
         </div>
@@ -77,88 +77,86 @@ class Body extends React.Component {
     const is57 = this.props.isFirefox && this.props.firefoxVersion >= 57;
     return (
       <reactruntime.BodyTemplate {...this.props}>
-        <div className="default-color-scheme">
-          <HomePageHeader isOwner={this.props.showMyShots} isFirefox={this.props.isFirefox}
-            hasFxa={this.props.hasFxa} />
-          <div className="banner">
-            <div className="banner-image-back" />
-            <div className="banner-container">
-              <div className="banner-content">
-                <h1>Firefox Screenshots</h1>
-                <Localized id="gScreenshotsDescription">
-                  <p>Screenshots made simple. Take, save, and share screenshots without leaving Firefox.</p>
-                </Localized>
-                { this.renderGetFirefox() }
-              </div>
-              <div className="banner-image-front" />
+        <HomePageHeader isOwner={this.props.showMyShots} isFirefox={this.props.isFirefox}
+          hasFxa={this.props.hasFxa} />
+        <div className="banner">
+          <div className="banner-image-back" />
+          <div className="banner-container">
+            <div className="banner-content">
+              <h1>Firefox Screenshots</h1>
+              <Localized id="gScreenshotsDescription">
+                <p>Screenshots made simple. Take, save, and share screenshots without leaving Firefox.</p>
+              </Localized>
+              {this.renderGetFirefox()}
             </div>
+            <div className="banner-image-front" />
           </div>
-          <Localized id="homePageHowScreenshotsWorks">
-            <h2 id="how-screenshots-works">How Screenshots Works</h2>
-          </Localized>
-          <section id="section-1">
+        </div>
+        <Localized id="homePageHowScreenshotsWorks">
+          <h2 id="how-screenshots-works">How Screenshots Works</h2>
+        </Localized>
+        <section id="section-1">
+          <div className="container">
+            <div className="section-content align-left">
+              <Localized id="homePageGetStartedTitle">
+                <h3>Get Started</h3>
+              </Localized>
+              {is57 ? (
+                <Localized id="homePageGetStartedDescriptionPageAction">
+                  <p>Select the Screenshots icon from the page actions menu in the address bar, and the Screenshots menu will appear on top of your browser window.</p>
+                </Localized>
+              ) : (
+                  <Localized id="homePageGetStartedDescription">
+                    <p>Find the new Screenshots icon on your toolbar. Select it, and the Screenshots menu will appear on top of your browser window.</p>
+                  </Localized>
+                )
+              }
+            </div>
+            <div className={classnames("section-image", "align-right", { "page-action": is57 })}></div>
+          </div>
+        </section>
+        <section id="section-2">
+          <div className="container">
+            <div className="section-content align-right">
+              <Localized id="homePageCaptureRegion">
+                <h3>Capture a Region</h3>
+              </Localized>
+              <Localized id="homePageCaptureRegionDescription">
+                <p>Click and drag to select the area you want to capture. Or just hover and click — Screenshots will select the area for you. Like what you see? Select Save to access your screenshot online or the down arrow button to download it to your computer.</p>
+              </Localized>
+            </div>
+            <div className="section-image align-left"></div>
+          </div>
+        </section>
+        {is57 &&
+          <section id="section-3">
             <div className="container">
               <div className="section-content align-left">
-                <Localized id="homePageGetStartedTitle">
-                  <h3>Get Started</h3>
+                <Localized id="homePageCapturePage">
+                  <h3>Capture a Page</h3>
                 </Localized>
-                { is57 ? (
-                    <Localized id="homePageGetStartedDescriptionPageAction">
-                      <p>Select the Screenshots icon from the page actions menu in the address bar, and the Screenshots menu will appear on top of your browser window.</p>
-                    </Localized>
-                  ) : (
-                    <Localized id="homePageGetStartedDescription">
-                      <p>Find the new Screenshots icon on your toolbar. Select it, and the Screenshots menu will appear on top of your browser window.</p>
-                    </Localized>
-                  )
-                }
-              </div>
-              <div className={classnames("section-image", "align-right", {"page-action": is57})}></div>
-            </div>
-          </section>
-          <section id="section-2">
-            <div className="container">
-              <div className="section-content align-right">
-                <Localized id="homePageCaptureRegion">
-                  <h3>Capture a Region</h3>
-                </Localized>
-                <Localized id="homePageCaptureRegionDescription">
-                  <p>Click and drag to select the area you want to capture. Or just hover and click — Screenshots will select the area for you. Like what you see? Select Save to access your screenshot online or the down arrow button to download it to your computer.</p>
+                <Localized id="homePageCapturePageDescription">
+                  <p>Use the buttons in the upper right to capture full pages. The Save Visible button will capture the area you can view without scrolling, and the Save Full Page will capture everything on the page.</p>
                 </Localized>
               </div>
-              <div className="section-image align-left"></div>
+              <div className="section-image align-right"></div>
             </div>
           </section>
-          { is57 &&
-              <section id="section-3">
-                <div className="container">
-                  <div className="section-content align-left">
-                    <Localized id="homePageCapturePage">
-                      <h3>Capture a Page</h3>
-                    </Localized>
-                    <Localized id="homePageCapturePageDescription">
-                      <p>Use the buttons in the upper right to capture full pages. The Save Visible button will capture the area you can view without scrolling, and the Save Full Page will capture everything on the page.</p>
-                    </Localized>
-                  </div>
-                  <div className="section-image align-right"></div>
-                </div>
-              </section>
-          }
-          <section id="section-4">
-            <div className="container">
-              <div className={classnames("section-content", {"align-right": is57}, {"align-left": !is57})}>
-                <Localized id="homePageSaveShare">
-                  <h3>Save and Share</h3>
-                </Localized>
-                <Localized id="homePageSaveShareDescription">
-                  <p>When you take a shot, Firefox posts your screenshot to your online Screenshots library and copies the link to your clipboard. We automatically store your screenshot for two weeks, but you can delete shots at any time or change the expiration date to keep them in your library for longer. </p>
-                </Localized>
-              </div>
-              <div className={classnames("section-image", {"align-left": is57}, {"align-right": !is57})}></div>
+        }
+        <section id="section-4">
+          <div className="container">
+            <div className={classnames("section-content", { "align-right": is57 }, { "align-left": !is57 })}>
+              <Localized id="homePageSaveShare">
+                <h3>Save and Share</h3>
+              </Localized>
+              <Localized id="homePageSaveShareDescription">
+                <p>When you take a shot, Firefox posts your screenshot to your online Screenshots library and copies the link to your clipboard. We automatically store your screenshot for two weeks, but you can delete shots at any time or change the expiration date to keep them in your library for longer. </p>
+              </Localized>
             </div>
-          </section>
-          <Footer {...this.props} />
-        </div>
+            <div className={classnames("section-image", { "align-left": is57 }, { "align-right": !is57 })}></div>
+          </div>
+        </section>
+        <Footer {...this.props} />
       </reactruntime.BodyTemplate>
     );
   }

--- a/server/src/pages/not-found/view.js
+++ b/server/src/pages/not-found/view.js
@@ -28,7 +28,7 @@ class Body extends React.Component {
   render() {
     return (
       <reactruntime.BodyTemplate {...this.props}>
-        <div className="column-space full-height default-color-scheme">
+        <div className="column-space full-height">
           <Header hasLogo={true} />
           <div id="shot-index" className="flex-1">
             <div className="no-shots" key="no-shots-found">

--- a/server/src/pages/shot/crop-tool.js
+++ b/server/src/pages/shot/crop-tool.js
@@ -123,7 +123,7 @@ exports.CropTool = class CropTool extends React.Component {
   }
 
   renderToolbar() {
-    return <div className="editor-header default-color-scheme"><div className="annotation-tools">
+    return <div className="editor-header"><div className="annotation-tools">
       <Localized id="annotationCropConfirmButton">
         <button className={`button transparent confirm-crop`} id="confirm-crop" onClick={this.onClickConfirm.bind(this)} title="Confirm selection">Crop</button>
       </Localized>

--- a/server/src/pages/shot/editor.js
+++ b/server/src/pages/shot/editor.js
@@ -86,7 +86,7 @@ exports.Editor = class Editor extends React.Component {
     const toolContent = this.state.isCanvasRendered ? this.renderSelectedTool() : null;
     const toolBar = this.state.isCanvasRendered ? this.renderToolBar() : null;
     const display = this.loader || this.renderCanvas(toolContent);
-    return <div className="inverse-color-scheme full-height column-space"
+    return <div className="full-height column-space"
       onMouseMove={this.onMouseMove.bind(this)}>
       { toolBar }
       { display }
@@ -96,7 +96,7 @@ exports.Editor = class Editor extends React.Component {
   renderCanvas(toolContent) {
     return <div className="main-container">
       <div
-        className={`inverse-color-scheme canvas-container ${this.state.tool}`}
+        className={`canvas-container ${this.state.tool}`}
         id="canvas-container"
         style={{ height: this.state.canvasCssHeight, width: this.state.canvasCssWidth }}>
         <canvas
@@ -183,7 +183,7 @@ exports.Editor = class Editor extends React.Component {
     const undoButtonState = this.state.canUndo ? "active" : "inactive";
     const redoButtonState = this.state.canRedo ? "active" : "inactive";
 
-    return <div className="editor-header default-color-scheme">
+    return <div className="editor-header">
       <div className="shot-main-actions annotation-main-actions">
         <div className="annotation-tools">
           <Localized id="annotationCropButton">

--- a/server/src/pages/shot/promo-dialog.js
+++ b/server/src/pages/shot/promo-dialog.js
@@ -10,7 +10,7 @@ exports.PromoDialog = class PromoDialog extends React.Component {
 
   render() {
     if (this.props.display) {
-      return <div id="promo-dialog-panel" className="promo-panel default-color-scheme" >
+      return <div id="promo-dialog-panel" className="promo-panel" >
         <Localized id="promoCloseButton">
           <a className="box-close" title="Close notification" onClick={this.closePanel.bind(this)}></a>
         </Localized>

--- a/server/src/pages/shot/text-tool.js
+++ b/server/src/pages/shot/text-tool.js
@@ -127,7 +127,7 @@ exports.TextTool = class TextTool extends React.Component {
   }
 
   renderToolbar() {
-    return <div className="editor-header default-color-scheme"><div className="annotation-tools">
+    return <div className="editor-header"><div className="annotation-tools">
       <Localized id="annotationTextSize">
         <select className={`text-select`} title="Text Size" onChange={this.onChangeTextSize.bind(this)} value={this.state.textSize}>
           <Localized id="textSizeSmall"><option value="small-text">Small</option></Localized>

--- a/server/src/pages/shotindex/view.js
+++ b/server/src/pages/shotindex/view.js
@@ -39,7 +39,7 @@ class Body extends React.Component {
   render() {
     return (
       <reactruntime.BodyTemplate {...this.props}>
-        <div className="column-space full-height default-color-scheme" id="shot-index-page">
+        <div className="column-space full-height" id="shot-index-page">
           <MyShotsHeader hasDeviceId={this.props.hasDeviceId} hasFxa={this.props.hasFxa}
             enableUserSettings={this.props.enableUserSettings} />
           { this.props.disableSearch ? null : this.renderSearchForm() }
@@ -204,7 +204,7 @@ class Body extends React.Component {
 
   renderSearchForm() {
     return (
-      <form id="search-form" className="default-color-scheme" onSubmit={ this.onSubmitForm.bind(this) }>
+      <form id="search-form" onSubmit={ this.onSubmitForm.bind(this) }>
         <span className="search-label" />
         <Localized id="shotIndexPageSearchPlaceholder">
           <input type="search" id="search" ref={searchInput => this.searchInput = searchInput} maxLength="100" placeholder="search my shots" defaultValue={this.state.defaultSearch} onChange={this.onChangeSearch.bind(this)} />

--- a/server/src/reactrender.js
+++ b/server/src/reactrender.js
@@ -53,7 +53,7 @@ exports.render = function(req, res, page) {
     let doc = `
     <html>
       ${head}
-      <body>
+      <body class="app-body">
         <div id="react-body-container">${body}</div>
         <script id="json-data" type="data">${jsonString}</script>
       </body></html>

--- a/server/src/share-buttons.js
+++ b/server/src/share-buttons.js
@@ -119,7 +119,7 @@ class ShareButtonPanel extends React.Component {
   }
 
   render() {
-    let className = "share-panel default-color-scheme";
+    let className = "share-panel";
     if (this.props.renderExtensionNotification) {
       className += " share-panel-with-notification";
     }

--- a/static/css/frame.scss
+++ b/static/css/frame.scss
@@ -150,15 +150,16 @@
 }
 
 .promo-panel {
-  position: absolute;
-  top: 90px;
-  right: -30px;
+  background: $white;
   border-radius: 3px;
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.3), 0 0 20px rgba(0, 0, 0, 0.2);
+  box-shadow: $stroke-box-shadow, $medium-box-shadow;
+  padding: 5px;
+  position: absolute;
+  right: -30px;
+  text-align: center;
+  top: 90px;
   width: 150px;
   z-index: 999;
-  padding: 5px;
-  text-align: center;
 
   .title {
     font-size: 14px;
@@ -269,6 +270,7 @@
   flex: 1;
 }
 
+// TODO: fix color literals in #3864
 .clips-warning {
   background: #ffe900;
   padding: 5px;
@@ -287,14 +289,17 @@
   flex: 0 auto;
   margin: 20px auto;
   max-width: 90%;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05), 0 0 0 1px rgba(0, 0, 0, 0.05);
+
+  img {
+    box-shadow: $large-box-shadow;
+  }
 }
 
 .link-button {
   cursor: pointer;
   color: $black;
   background: transparent;
-  border: 1px solid #d4d4d4;
+  border: 1px solid $light-active;
   padding: 4px;
   border-radius: 4px;
 }
@@ -384,7 +389,7 @@
 }
 
 .annotation-divider {
-  border-right: 1px solid #989a9c;
+  border-right: 1px solid $light-border-active;
   margin: auto auto;
   width: 1px;
   height: 28px;
@@ -393,14 +398,12 @@
 html {
   min-height: 100%;
   position: relative;
-  background-color: #38383d;
 }
 
 body {
   width: 100%;
   margin: 0;
   height: 100%;
-  background-color: #38383d;
 }
 
 .editor-header {
@@ -434,7 +437,7 @@ body {
 
   .cancel {
     background-color: $light-default;
-    border: 1px solid #9b9b9b;
+    border: 1px solid $light-border-active;
 
     &:hover,
     &:focus {
@@ -451,8 +454,8 @@ body {
   margin: $grid-unit;
   display: flex;
   flex-direction: row;
-  background: #fff;
-  box-shadow: rgba(0, 0, 0, 0.15) 0 2px 4px;
+  background: $white;
+  box-shadow: $medium-box-shadow;
   border-radius: $border-radius;
   height: 50px;
 }
@@ -484,7 +487,7 @@ body {
 }
 
 .canvas-container {
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05), 0 0 0 1px rgba(0, 0, 0, 0.05);
+  box-shadow: $large-box-shadow;
   display: flex;
   justify-content: center;
   margin: 20px auto;
@@ -565,9 +568,8 @@ body {
   height: 160px;
   position: absolute;
   background: $light-default;
-  border: 1px solid $light-border;
-  border-radius: 10px;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05), 0 0 0 1px rgba(0, 0, 0, 0.05);
+  border-radius: $border-radius;
+  box-shadow: $stroke-box-shadow, $medium-box-shadow;
   padding: 20px;
 
   .triangle {
@@ -576,7 +578,7 @@ body {
     height: 0;
     border-left: 10px solid transparent;
     border-right: 10px solid transparent;
-    border-bottom: 15px solid $light-border;
+    border-bottom: 15px solid $light-active;
     top: -15px;
     left: 9.5px;
 
@@ -607,7 +609,7 @@ body {
 
   &:hover
     {
-      border: 3px solid #d4d4d4 !important;
+      border: 3px solid $light-active !important;
     }
 }
 
@@ -735,11 +737,11 @@ $bg-white: rgba(255, 255, 255, 0.7);
 .textTool {
 
   .black {
-    @include type-color($bg-white, black);
+    @include type-color($bg-white, $black);
   }
 
   .white {
-    @include type-color($bg-black, white);
+    @include type-color($bg-black, $white);
   }
 
   .red {

--- a/static/css/home.scss
+++ b/static/css/home.scss
@@ -74,14 +74,14 @@ body {
 }
 
 .banner-content h1 {
-  color: #fff;
+  color: $white;
   font-size: 3em;
   font-weight: 400;
   margin: 0 0 20px;
 }
 
 .banner-content p {
-  color: #fff;
+  color: $white;
   font-size: 1.3em;
   font-weight: 400;
   line-height: 1.61;
@@ -104,7 +104,7 @@ h2 {
   -webkit-user-select: none;
   border-radius: 3px;
   border: 1px solid transparent;
-  box-shadow: rgba(0, 0, 0, 0.09) 0 6px 9px;
+  box-shadow: $medium-box-shadow;
   cursor: pointer;
   display: inline-block;
   font-weight: 400;
@@ -127,7 +127,7 @@ h2 {
   -ms-user-select: none;
   -webkit-user-select: none;
   align-items: center;
-  color: #fff;
+  color: $white;
   display: -ms-flexbox;
   display: flex;
   flex-direction: row;
@@ -146,13 +146,14 @@ h2 {
   color: #fff;
   text-align: left;
 
-  &:hover {
+  &:hover,
+  &:focus {
     background: #20c60b;
   }
 
   &:active {
     background: #10b60b;
-    box-shadow: rgba(0, 0, 0, 0.09) 0 3px 4px;
+    box-shadow: $small-box-shadow;
   }
 
 }
@@ -170,14 +171,14 @@ h2 {
 }
 
 .download-firefox .button-icon-badge {
-  background-color: #fff;
+  background-color: $white;
   background-image:   url("../img/landing-download-icon@2x.png");
   background-position: 50%;
   background-repeat: no-repeat;
   background-size: 14px 14px;
   border-radius: 50%;
   bottom: 4px;
-  box-shadow: 0 2px 0 rgba(0, 0, 0, 0.2);
+  box-shadow: $small-box-shadow;
   height: 16px;
   padding: 6px;
   position: absolute;

--- a/static/css/partials/_animations.scss
+++ b/static/css/partials/_animations.scss
@@ -1,19 +1,15 @@
 .loader {
-  background: #2e2d30;
+  background: rgba(12, 12, 13, 0.2);
   border-radius: 2px;
   height: 4px;
   overflow: hidden;
   position: relative;
   width: 200px;
-
-  #shot-index & {
-    background-color: $light-active;
-  }
 }
 
 .loader-inner {
   animation: bounce infinite alternate 1250ms cubic-bezier(0.7, 0, 0.3, 1);
-  background: #04d1e6;
+  background: $active-blue;
   border-radius: 2px;
   height: 4px;
   transform: translateX(-40px);

--- a/static/css/partials/_delete-confirmation.scss
+++ b/static/css/partials/_delete-confirmation.scss
@@ -3,10 +3,10 @@
 }
 
 .delete-confirmation-dialog {
-  background-color: #fff;
-  border: 1px solid #c7c7c7 ;
+  background-color: $white;
+  border: 1px solid $light-border;
   border-radius: 3px;
-  box-shadow: 0 5px 11px 0 rgba(0, 0, 0, 0.25), 0 0 0 0 rgba(0, 0, 0, 0.29), inset 0 0 0 0 #fff;
+  box-shadow: $medium-box-shadow;
   min-height: 114px;
   min-width: 320px;
   padding: 18px;
@@ -31,7 +31,7 @@
       height: 0;
       border-left: 8px solid transparent;
       border-right: 8px solid transparent;
-      border-bottom: 13px solid #fff;
+      border-bottom: 13px solid $white;
       left: -8px;
       top: 2px;
     }

--- a/static/css/partials/_footer.scss
+++ b/static/css/partials/_footer.scss
@@ -19,6 +19,10 @@
     li {
       font-size: 14px;
       margin-right: 16px;
+
+      a {
+        color: $gray;
+      }
     }
   }
 
@@ -29,17 +33,5 @@
     display: block;
     height: $grid-unit * 1.5;
     width: $grid-unit * 6;
-  }
-
-  .inverse-color-scheme & {
-    .mozilla-logo {
-      background-image: url("../img/mozilla-white.svg");
-    }
-  }
-
-  .default-color-scheme & {
-    .mozilla-logo {
-      background-image: url("../img/mozilla.svg");
-    }
   }
 }

--- a/static/css/partials/_header.scss
+++ b/static/css/partials/_header.scss
@@ -1,7 +1,7 @@
 .header-panel {
   @include respond-to("medium") {
     @include flex-container(row, space-between, center);
-    height: $grid-unit * 5;
+    height: $grid-unit * 4.8;
   }
 
   @include respond-to("small") {
@@ -50,7 +50,6 @@
 
   .nav-button {
     @include flex-container(column, center, center);
-    color: #4a4a4a;
     cursor: pointer;
     text-decoration: none;
     background-color: transparent;
@@ -59,7 +58,6 @@
     display: flex;
     flex-basis: 96px;
     font-size: 14px;
-    color: #2a2a2e;
     font-weight: bold;
     height: 96px;
     width: 96px;

--- a/static/css/partials/_partials.scss
+++ b/static/css/partials/_partials.scss
@@ -11,6 +11,4 @@
 @import "large-icon-block";
 @import "share-panel";
 @import "header";
-
-// Theme
 @import "theme";

--- a/static/css/partials/_share-panel.scss
+++ b/static/css/partials/_share-panel.scss
@@ -10,8 +10,9 @@
     width: 100%;
   }
 
+  background: $white;
   border-radius: $border-radius;
-  box-shadow: 0 0 0 1px rgba(#000, 0.3), 0 0 20px rgba(#000, 0.2);
+  box-shadow: $stroke-box-shadow, $medium-box-shadow;
   position: absolute;
   right: 10px;
   top: 90px;

--- a/static/css/partials/_theme.scss
+++ b/static/css/partials/_theme.scss
@@ -1,14 +1,4 @@
-.inverse-color-scheme {
-  background: $dark-default;
-  color: $light-default;
-
-  a {
-    color: $link-light;
-  }
-}
-
-
-.default-color-scheme {
+.app-body {
   background: $light-default;
   color: $dark-default;
 
@@ -76,7 +66,7 @@
     &:hover {
       background-color: $light-hover;
     }
-    
+
     &:focus,
     &:active {
       background-color: $light-active;

--- a/static/css/partials/_variables.scss
+++ b/static/css/partials/_variables.scss
@@ -13,8 +13,8 @@ $light-border-active: #989898;
 $light-hover: #ededf0;
 $light-active: #dedede;
 $light-default: #f9f9fa;
-$link-blue: #009ec0;
-$active-blue: #00d1e6;
+$link-blue: #0a84ff;
+$active-blue: #45a1ff;
 $link-light: #e1e1e6;
 $link-medium: #858585;
 $warning: #d92215;
@@ -29,3 +29,8 @@ $border-radius: 3px;
 
 // ANIMATION CURVE
 $bezier: cubic-bezier(0.07, 0.95, 0, 1);
+
+$stroke-box-shadow: 0 0 0 1px rgba(12, 12, 13, 0.1);
+$small-box-shadow: 0 1px 4px rgba(12, 12, 13, 0.1);
+$medium-box-shadow: 0 2px 8px	rgba(12, 12, 13, 0.1);
+$large-box-shadow: 0 4px 16px rgba(12, 12, 13, 0.1);

--- a/static/css/shot-index.scss
+++ b/static/css/shot-index.scss
@@ -1,26 +1,9 @@
 @import "partials/partials";
 @import "partials/delete-confirmation";
 
+$shot-width: 210px;
+
 //Shot index page styles
-
-#shot-index-page {
-  background: $light-default;
-}
-
-#shot-index {
-  @include respond-to("small") {
-    width: 480px;
-  }
-
-  @include respond-to("medium") {
-    width: 720px;
-  }
-
-  @include respond-to("large") {
-    width: 960px;
-  }
-}
-
 
 #search-form {
   @include flex-container(row, flex-start, stretch);
@@ -58,7 +41,7 @@
     font-size: 16px;
     padding: 0 28px 8px 24px;
     transition: border-color $bezier 150ms;
-    width: 210px;
+    width: $shot-width;
 
     &:focus {
       border-bottom-color: $link-blue;
@@ -76,15 +59,28 @@
 
 #shot-index {
   @include flex-container(column, flex-start, stretch);
-  margin: 10px auto;
+
+  @include respond-to("small") {
+    width: 480px;
+  }
+
+  @include respond-to("medium") {
+    width: 720px;
+  }
+
+  @include respond-to("large") {
+    width: 960px;
+  }
+
+  margin: 24px auto;
 }
 
 .shot {
   background: $white;
-  box-shadow: 0 0  0 1px rgba(0, 0, 0, 0.05);
+  box-shadow: $medium-box-shadow;
   margin: 15px;
   transition: box-shadow 250ms $bezier;
-  width: 210px;
+  width: $shot-width;
 
   .share-panel {
     left: 0;
@@ -105,7 +101,7 @@
 
   &:hover,
   &.panel-open {
-    box-shadow: 0 0 0 5px $light-border;
+    box-shadow: 0 0 0 5px $light-active;
 
     .alt-actions-container {
       opacity: 1;
@@ -119,7 +115,7 @@
   .shot-image-container {
     background-size: cover;
     box-shadow: 0 -1px 0 rgba(0, 0, 0, 0.05) inset;
-    width: 210px;
+    width: $shot-width;
     overflow: hidden;
   }
 
@@ -133,20 +129,20 @@
   &.portrait .shot-image-container {
     height: 280px;
     img {
-      width: 210px;
+      width: $shot-width;
     }
   }
 
   &.square-x .shot-image-container {
-    height: 210px;
+    height: $shot-width;
     img {
-      width: 210px;
+      width: $shot-width;
     }
   }
   &.square-y .shot-image-container {
-    height: 210px;
+    height: $shot-width;
     img {
-      height: 210px;
+      height: $shot-width;
     }
   }
 


### PR DESCRIPTION
Fixes #4845

This aslo reduces a bunch of complexity by getting rid of all the `default-color-scheme` and `inverse-color-scheme` classes peppered throughout the server views.

Also variable-ized most of the color values and drop shadows that were declared as literals in css and updated the default blues to match photon.