### PR TITLE
Change 'save' button to 'upload' button

### DIFF
--- a/locales/en-US/webextension.properties
+++ b/locales/en-US/webextension.properties
@@ -6,6 +6,7 @@ contextMenuLabel = Take a Screenshot
 myShotsLink = My Shots
 screenshotInstructions = Drag or click on the page to select a region. Press ESC to cancel.
 saveScreenshotSelectedArea = Save
+uploadScreenshotSelectedArea = Upload
 saveScreenshotVisibleArea = Save visible
 saveScreenshotFullPage = Save full page
 cancelScreenshot = Cancel

--- a/webextension/selector/ui.js
+++ b/webextension/selector/ui.js
@@ -420,9 +420,9 @@ this.ui = (function() { // eslint-disable-line no-unused-vars
                           data-l10n-title="downloadScreenshot"><img
                           src="${browser.extension.getURL("icons/download.svg")}" /></button>
                          <button class="preview-button-save"
-                          data-l10n-title="saveScreenshotSelectedArea"><img
+                          data-l10n-title="uploadScreenshotSelectedArea"><img
                           src="${browser.extension.getURL("icons/cloud.svg")}"
-                          />${browser.i18n.getMessage("saveScreenshotSelectedArea")}</button>`
+                          />${browser.i18n.getMessage("uploadScreenshotSelectedArea")}</button>`
                       }
                     </div>
                   </div>
@@ -727,8 +727,8 @@ this.ui = (function() { // eslint-disable-line no-unused-vars
         const saveImg = makeEl("img");
         saveImg.src = browser.extension.getURL("icons/cloud.svg");
         save.appendChild(saveImg);
-        save.append(browser.i18n.getMessage("saveScreenshotSelectedArea"));
-        save.title = browser.i18n.getMessage("saveScreenshotSelectedArea");
+        save.append(browser.i18n.getMessage("uploadScreenshotSelectedArea"));
+        save.title = browser.i18n.getMessage("uploadScreenshotSelectedArea");
       }
       buttons.appendChild(download);
       if (save) {


### PR DESCRIPTION
I think we were wrong to use 'Save' to mean 'Upload', and I don't recall why we went with it in the first place. It could seem like we're desperate to trick people into uploading shots. Let's not give that impression.

<img width="740" alt="screen shot 2018-09-26 at 1 10 48 pm" src="https://user-images.githubusercontent.com/96396/46106805-87a42b00-c18e-11e8-9af7-6b5fb743f794.png">
