### PR TITLE
Define button color

### DIFF
--- a/static/css/inline-selection.scss
+++ b/static/css/inline-selection.scss
@@ -586,6 +586,7 @@ $very-light-grey: #ededed;
 
   button {
     @include flex-container(column, flex-end, center);
+    color: #3e3d40;
     background-color: #f5f5f5;
     background-position: center top;
     background-repeat: no-repeat;


### PR DESCRIPTION
In **Linux desktop with dark theme**, default button text color is white or light gray. If button background is set to a light color, button text are not visible. So button text color and background color must both be defined.

Before:

![screenshot_20181005_120700](https://user-images.githubusercontent.com/5836790/46526290-85c91e80-c896-11e8-8089-6e146c382423.png)

After:

![screenshot_20181005_120727](https://user-images.githubusercontent.com/5836790/46526313-96799480-c896-11e8-94df-1df8159a3e21.png)
