### PR TITLE
Add new onboarding image to manifest

### DIFF
--- a/webextension/manifest.json.template
+++ b/webextension/manifest.json.template
@@ -59,6 +59,7 @@
     "icons/onboarding-3.png",
     "icons/onboarding-4.png",
     "icons/onboarding-5.png",
+    "icons/onboarding-6.png",
     "icons/done.svg",
     "icons/icon-welcome-face-without-eyes.svg"
   ],


### PR DESCRIPTION
The image shown in the new onboarding step (`onboarding-6.png`) should not be loaded by the webextension unless it's explicitly declared in the `web_accessible_resources` part of the manifest. I'm not sure why it's working, but it seems like an upstream bug; by adding it to the manifest, onboarding will continue to work when the bug's fixed.