### PR TITLE
Fixes #5074 - Hide Signin banner on non-owned shot if authenticated

### DIFF
--- a/server/src/pages/shot/controller.js
+++ b/server/src/pages/shot/controller.js
@@ -39,7 +39,6 @@ function shouldShowPromo(model) {
 function updateModel(authData) {
   Object.assign(model, authData);
   model.isExtInstalled = true;
-  model.isFxaAuthenticated = model.accountId && model.accountId === model.shotAccountId;
 }
 
 exports.launch = function(data) {

--- a/server/src/pages/shot/model.js
+++ b/server/src/pages/shot/model.js
@@ -12,7 +12,6 @@ exports.createModel = function(req) {
   }
   const title = req.getText("shotPageTitle", {originalTitle: req.shot.title});
   const enableAnnotations = req.config.enableAnnotations;
-  const isFxaAuthenticated = req.accountId && req.accountId === req.shot.accountId;
   const copyImageErrorMessage = {
     title: req.getText("copyImageErrorTitle"),
     message: req.getText("copyImageErrorMessage"),
@@ -28,7 +27,6 @@ exports.createModel = function(req) {
     productName: req.config.productName,
     isExtInstalled: !!req.deviceId,
     isOwner: req.shot.isOwner,
-    isFxaAuthenticated,
     gaId: req.config.gaId,
     deviceId: req.deviceId,
     buildTime,
@@ -57,7 +55,6 @@ exports.createModel = function(req) {
     productName: req.config.productName,
     isExtInstalled: !!req.deviceId,
     isOwner: req.shot.isOwner,
-    isFxaAuthenticated,
     gaId: req.config.gaId,
     deviceId: req.deviceId,
     shotAccountId: req.shot.accountId,

--- a/server/src/pages/shot/shotpage-header.js
+++ b/server/src/pages/shot/shotpage-header.js
@@ -91,7 +91,7 @@ exports.ShotPageHeader = class ShotPageHeader extends React.Component {
     if (this.props.isOwner) {
       return (
         <div className="shot-fxa-signin">
-          <SignInButton isFxaAuthenticated={this.props.isFxaAuthenticated} initialPage={this.props.shot.id}
+          <SignInButton isFxaAuthenticated={this.props.hasFxa} initialPage={this.props.shot.id}
                         staticLink={this.props.staticLink} />
         </div>
       );
@@ -114,7 +114,7 @@ exports.ShotPageHeader = class ShotPageHeader extends React.Component {
 
     return (
       <Header shouldGetFirefox={this.props.shouldGetFirefox} isOwner={this.props.isOwner}
-              hasFxa={this.props.isFxaAuthenticated}>
+              hasFxa={this.props.hasFxa}>
         { myShotsText }
         { shotInfo }
         { shotActions }
@@ -129,7 +129,7 @@ exports.ShotPageHeader.propTypes = {
   children: PropTypes.node,
   isOwner: PropTypes.bool,
   shot: PropTypes.object,
-  isFxaAuthenticated: PropTypes.bool,
+  hasFxa: PropTypes.bool,
   expireTime: PropTypes.number,
   shouldGetFirefox: PropTypes.bool,
   shotActions: PropTypes.array,

--- a/server/src/pages/shot/view.js
+++ b/server/src/pages/shot/view.js
@@ -381,12 +381,12 @@ class Body extends React.Component {
           </div> : null;
       const favImgSrc = this.props.expireTime ? this.props.staticLink("/static/img/icon-heart-outline.svg") :
         this.props.staticLink("/static/img/icon-heart.svg");
-      const inactive = this.props.isFxaAuthenticated ? "" : "inactive";
+      const inactive = this.props.hasFxa ? "" : "inactive";
 
       favoriteShotButton = <div className="favorite-shot-button" key="favorite-shot-button">
         <Localized id="shotPagefavoriteButton" attrs={{title: true}}>
           <button className={`button transparent nav-button ${inactive}`}
-                  disabled={!this.props.isFxaAuthenticated} onClick={this.onClickFavorite.bind(this)}>
+                  disabled={!this.props.hasFxa} onClick={this.onClickFavorite.bind(this)}>
             <img src={favImgSrc} />
           </button>
         </Localized></div>;
@@ -443,7 +443,7 @@ class Body extends React.Component {
     return (
       <reactruntime.BodyTemplate {...this.props}>
         <div id="frame" className="inverse-color-scheme full-height column-space">
-        <ShotPageHeader isOwner={this.props.isOwner} isFxaAuthenticated={this.props.isFxaAuthenticated}
+        <ShotPageHeader isOwner={this.props.isOwner} hasFxa={this.props.hasFxa}
           shot={this.props.shot} expireTime={this.props.expireTime} shouldGetFirefox={renderGetFirefox}
           staticLink={this.props.staticLink} shotActions={shotActions}>
             { !this.props.isOwner ? downloadButton : null }
@@ -572,7 +572,7 @@ Body.propTypes = {
   isExtInstalled: PropTypes.bool,
   isMobile: PropTypes.bool,
   isOwner: PropTypes.bool,
-  isFxaAuthenticated: PropTypes.bool,
+  hasFxa: PropTypes.bool,
   loginFailed: PropTypes.bool,
   pngToJpegCutoff: PropTypes.number,
   retentionTime: PropTypes.number,


### PR DESCRIPTION
PR fixes hiding signin banner on non-owned shots if user has logged in on a device with Firefox Account.
Fix involves passing hasFxa prop to shotpag header that has accountId auth value set from cookie instead of isFxaAuthenticated value set in model.js that double checks if accountId cookie is same as associated accountId in database which will be false for non-owned shots