### PR TITLE
Make share buttons focusable

### DIFF
--- a/server/src/share-buttons.js
+++ b/server/src/share-buttons.js
@@ -126,17 +126,17 @@ class ShareButtonPanel extends React.Component {
     return <div id="share-buttons-panel" className={className} ref={shareDiv => this.shareDiv = shareDiv} style={{top: this.state.top, left: this.state.left}}>
       <div className="wrapper row-wrap share-buttons">
         <Localized id="shotPageShareFacebook" attrs={{title: true}}>
-          <a title="Share to Facebook wall or message" onClick={ this.onClickShareButton.bind(this, "facebook", "https://www.facebook.com/sharer/sharer.php?u=" + encodeURIComponent(this.props.shot.viewUrl)) }>
+          <a title="Share to Facebook wall or message" href="#" onClick={ this.onClickShareButton.bind(this, "facebook", "https://www.facebook.com/sharer/sharer.php?u=" + encodeURIComponent(this.props.shot.viewUrl)) }>
             <img src={ this.props.staticLink("/static/img/btn-fb.svg") } />
           </a>
         </Localized>
         <Localized id="shotPageShareTwitter" attrs={{title: true}}>
-          <a title="Share to a tweet" onClick={ this.onClickShareButton.bind(this, "twitter", "https://twitter.com/home?status=" + encodeURIComponent(this.props.shot.viewUrl)) }>
+          <a title="Share to a tweet" href="#" onClick={ this.onClickShareButton.bind(this, "twitter", "https://twitter.com/home?status=" + encodeURIComponent(this.props.shot.viewUrl)) }>
             <img src={ this.props.staticLink("/static/img/btn-twitter.svg") } />
           </a>
         </Localized>
         <Localized id="shotPageSharePinterest" attrs={{title: true}}>
-          <a title="Share to Pinterest" onClick={ this.onClickShareButton.bind(this, "pinterest", "https://pinterest.com/pin/create/button/?url=" + encodeURIComponent(this.props.shot.viewUrl) + "&media=" + encodeURIComponent(this.props.clipUrl) + "&description=" + encodeURIComponent(this.props.shot.title)) }>
+          <a title="Share to Pinterest" href="#" onClick={ this.onClickShareButton.bind(this, "pinterest", "https://pinterest.com/pin/create/button/?url=" + encodeURIComponent(this.props.shot.viewUrl) + "&media=" + encodeURIComponent(this.props.clipUrl) + "&description=" + encodeURIComponent(this.props.shot.title)) }>
             <img src={ this.props.staticLink("/static/img/btn-pinterest.svg") } />
           </a>
         </Localized>


### PR DESCRIPTION
Fixes #4412 by adding a blank href attribute to the share buttons.

Unfortunately, it adds an extra entry to the history, but https://github.com/mozilla-services/screenshots/issues/3357 suggests that adding something "useful" in the href attribute results in a tab that can't be closed after completing the social flow.

Tabbing demo:
![tabbable_shares](https://user-images.githubusercontent.com/9583167/47610034-1d3a1100-da00-11e8-83ea-d754e53234bc.gif)

Accessibility inspector showing focusable attribute:
<img width="842" alt="screen shot 2018-10-27 at 3 38 22 pm" src="https://user-images.githubusercontent.com/9583167/47610046-57a3ae00-da00-11e8-857e-3757399ebee8.png">
