### PR TITLE
Fixes #5074 - Hide signin promo on not found pages if authenticated

### DIFF
--- a/server/src/pages/not-found/view.js
+++ b/server/src/pages/not-found/view.js
@@ -29,7 +29,7 @@ class Body extends React.Component {
     return (
       <reactruntime.BodyTemplate {...this.props}>
         <div className="column-space full-height">
-          <Header hasLogo={true} />
+          <Header hasLogo={true} hasFxa={this.props.hasFxa} />
           <div id="shot-index" className="flex-1">
             <div className="no-shots" key="no-shots-found">
               <Localized id="gNoShots" attrs={{alt: true}}>


### PR DESCRIPTION
Fix of #5074 to hide [signin promo on not found pages](https://github.com/mozilla-services/screenshots/issues/5074#issuecomment-434242854) if a user has accountId cookie