### PR TITLE
Show expiration info on all screen sizes. Fixes: #5068

### DIFF
--- a/static/css/frame.scss
+++ b/static/css/frame.scss
@@ -71,13 +71,9 @@
   .expire-info {
     display: block;
     @include respond-to("small") {
-      display: none;
-    }
-    @include respond-to("large") {
-      display: none;
-    }
-    @include respond-to("extra-large") {
-      display: block;
+      &.time-diff {
+        display: none;
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes #5068

The fix includes showing full expiration info on all sizes but `small`.
For `small`, the `time-diff` part is removed.

Example:
![screenshot_2018-10-31 firefox privacy notice](https://user-images.githubusercontent.com/633345/47806456-81334100-dd42-11e8-9753-679fcd7b2740.png)
