### PR TITLE
Update 'async' keyword for sarge 0.1.5

### DIFF
--- a/test/server/test_file_management.py
+++ b/test/server/test_file_management.py
@@ -149,7 +149,7 @@ def restart_server(**extra_env):
     else:
         env_print = ''
     print('  Starting server%s' % env_print)
-    server = run('./bin/run-server --no-auto', cwd=project_base, env=env, stdout=server_out, async=True)
+    server = run('./bin/run-server --no-auto', cwd=project_base, env=env, stdout=server_out, async_=True)
     server_options = extra_env
     time.sleep(3)
     text = []


### PR DESCRIPTION
Rename keyword arg `async` to `async_`, as mentioned in the sarge 0.1.5 [changelog](https://sarge.readthedocs.io/en/latest/overview.html#change-log).

This gets the tests passing for me locally.