### PR TITLE
Fix Python test regression

### DIFF
--- a/test/server/test_file_management.py
+++ b/test/server/test_file_management.py
@@ -149,7 +149,7 @@ def restart_server(**extra_env):
     else:
         env_print = ''
     print('  Starting server%s' % env_print)
-    server = run('./bin/run-server --no-auto', cwd=project_base, env=env, stdout=server_out, async=True)
+    server = run('./bin/run-server --no-auto', cwd=project_base, env=env, stdout=server_out, async_=True)
     server_options = extra_env
     time.sleep(3)
     text = []


### PR DESCRIPTION
Due to a update in sarge for Python 3 compatibility, we have to use async_= instead of async=