### PR TITLE
Add missing "=" for gNoShots in en-US server.ftl file

### DIFF
--- a/locales/en-US/server.ftl
+++ b/locales/en-US/server.ftl
@@ -4,7 +4,7 @@
 ## Global phrases shared across pages, prefixed with 'g'
 gMyShots = My Shots
 gHomeLink = Home
-gNoShots
+gNoShots =
     .alt = No shots found
 gScreenshotsDescription = Screenshots made simple. Take, save, and share screenshots without leaving Firefox.
 


### PR DESCRIPTION
/cc @flodolo @Pike 

I wasn't seeing this as an error/warning on Pontoon or when trying to run <kbd>$ compare-locales --validate l10n.toml .</kbd> locally, but maybe it's a special case because it's in the reference "en-US" locale.

Fixes #5189