### PR TITLE
fast fixes for fxa styles

### DIFF
--- a/server/src/pages/shot/editor.js
+++ b/server/src/pages/shot/editor.js
@@ -218,11 +218,11 @@ exports.Editor = class Editor extends React.Component {
         </div>
       </div>
       <div className="shot-edit-alt-actions">
-        <Localized id="annotationSaveEditButton" attrs={{title: true}}>
-          <button className="button primary save" id="save" onClick={ this.onClickSave.bind(this) } disabled = { this.state.actionsDisabled } title="Save edit">Save</button>
-        </Localized>
         <Localized id="annotationCancelEditButton" attrs={{title: true}}>
           <button className="button secondary cancel" id="cancel" onClick={this.onClickCancel.bind(this)} title="Cancel editing" disabled = { this.state.actionsDisabled }>Cancel</button>
+        </Localized>
+        <Localized id="annotationSaveEditButton" attrs={{ title: true }}>
+          <button className="button primary save" id="save" onClick={this.onClickSave.bind(this)} disabled={this.state.actionsDisabled} title="Save edit">Save</button>
         </Localized>
       </div>
     </div>;

--- a/server/src/pages/shot/shotpage-header.js
+++ b/server/src/pages/shot/shotpage-header.js
@@ -70,7 +70,9 @@ exports.ShotPageHeader = class ShotPageHeader extends React.Component {
           <EditableTitle title={shot.title} isOwner={this.props.isOwner} />
           <div className="shot-subtitle">
             { linkTextShort ? <a className="subtitle-link" rel="noopener noreferrer" href={ shot.url } target="_blank" onClick={ this.onClickOrigUrl.bind(this, "navbar") }>{ linkTextShort }</a> : null }
+            { linkTextShort ? <span>&nbsp;&bull;&nbsp;</span> : null }
             <span className="time-diff expire-info">{ timeDiff }</span>
+            <span>&nbsp;&bull;&nbsp;</span>
             { expirationSubtitle }
           </div>
         </div>

--- a/static/css/frame.scss
+++ b/static/css/frame.scss
@@ -71,7 +71,8 @@
   .expire-info {
     display: block;
     @include respond-to("small") {
-      &.time-diff {
+      &.time-diff,
+      & + span {
         display: none;
       }
     }
@@ -149,11 +150,12 @@
 
   &.editable {
     cursor: default;
-    padding-inline-end: 28px;
+    padding-inline-end: 32px;
 
     &:hover {
       @include respond-to("large") {
         background-size: 24px 24px;
+        background-position: right 9px;
       }
       background-image: url("/static/img/pencil.svg");
       background-position: right 5px;
@@ -185,26 +187,20 @@
     padding-bottom: 1px;
     margin: 0 0 4px 0;
   }
-  font-weight: bold;
-  font-size: 24px;
-  line-height: 29px;
-  padding-bottom: 1px;
-  padding-inline-start: 2px;
 
   border-radius: $border-radius;
   border: 1px solid $active-blue;
-  
+  font-size: 24px;
+  font-weight: bold;
+  inset-inline-start: -3px;
+  line-height: 29px;
   margin: 0;
-  overflow: auto;
   max-width: 100px;
+  overflow: auto;
+  padding-bottom: 1px;
+  padding-inline-start: 2px;
   position: relative;
   top: -2px;
-  inset-inline-start: -3px;
-}
-
-.subtitle-link,
-.time-diff {
-  margin-inline-end: 8px;
 }
 
 .subtitle-link {
@@ -428,7 +424,6 @@ body {
 .editor-header {
   @include respond-to("medium") {
     @include flex-container(row, space-between, stretch, wrap);
-    height: $grid-unit * 5;
   }
 
   @include respond-to("small") {
@@ -436,16 +431,16 @@ body {
     height: $grid-unit * 7;
   }
   display: flex;
-  height: 100px;
+  height: 96px;
   z-index: 2;
   position: fixed;
   width: 100%;
+  pointer-events: none;
 
   .shot-edit-main-actions {
     @include respond-to("medium") {
       @include flex-container(row, flex-start, center);
       margin-inline-end: 10px;
-      padding-top: 4px;
     }
 
     @include respond-to("small") {
@@ -465,10 +460,12 @@ body {
 
   .shot-edit-alt-actions {
     @include flex-container(row, flex-end, center);
+    margin: 0 20px;
   }
 
   .button {
-    margin: $grid-unit * 0.25;
+    margin-inline: $grid-unit * 0.5;
+    pointer-events: all;
   }
 
   .cancel,
@@ -496,13 +493,15 @@ body {
 }
 
 .annotation-tools {
-  margin: $grid-unit;
+  margin: auto $grid-unit;
   display: flex;
   flex-direction: row;
+  align-items: center;
   background: $white;
   box-shadow: $medium-box-shadow;
   border-radius: $border-radius;
   height: 50px;
+  pointer-events: all;
 }
 
 .annotation-main-actions {
@@ -518,11 +517,13 @@ body {
 }
 
 .main-container {
+  align-items: center;
   display: flex;
   flex-direction: column;
   flex: 1;
   justify-content: center;
-  margin-top: $grid-unit * 5;
+  margin: $grid-unit auto;
+  padding: $grid-unit * 4.8;
   position: relative;
   z-index: 1;
 
@@ -535,8 +536,8 @@ body {
   box-shadow: $large-box-shadow;
   display: flex;
   justify-content: center;
-  margin: 20px auto;
   z-index: 9999;
+  position: relative;
 }
 
 .canvas-container .image-holder {
@@ -566,20 +567,20 @@ body {
 
 .centered {
   position: absolute;
-  margin: auto;
   overflow: hidden;
   top: 0;
   bottom: 0;
 }
 
 #color-button-container {
-  min-width: 40px;
-  margin: 0 5px;
+  width: 40px;
+  height: 40px;
+  margin: 5px 10px;
+  position: relative;
 }
 
 #color-button-highlight {
   display:none;
-  margin-top: $grid-unit/4;
   min-width: 40px;
   height: 40px;
   border-radius: 3px;
@@ -592,7 +593,7 @@ body {
   position: absolute;
   height: 22px;
   width: 22px;
-  margin-top: 13.5px;
+  margin-top: 9.5px;
   margin-inline-end: 10px;
   margin-bottom: 0;
   margin-inline-start: 9px;

--- a/static/css/partials/_header.scss
+++ b/static/css/partials/_header.scss
@@ -9,13 +9,10 @@
 
   @include respond-to("large") {
     @include flex-container(row, center, center);
-    flex-basis: $grid-unit * 4.8;
   }
 
   background-color: $light-default;
   display: flex;
-  flex-basis: $grid-unit * 6.5;
-  height: 100%;
   width: 100%;
 
   .logo {
@@ -60,12 +57,6 @@
     position: relative;
   }
 
-  a.nav-button {
-    &:focus {
-      outline: 1px dotted $black;
-    }
-  }
-
   .nav-button {
     @include flex-container(column, center, center);
 
@@ -89,8 +80,10 @@
     height: 60px;
     width: 60px;
     border: none;
+    transition: background 125ms;
 
-    &:hover {
+    &:hover,
+    &:focus {
       background-color: $light-hover;
       border-radius: 0;
     }
@@ -112,8 +105,8 @@
     }
 
     &.inactive {
-      opacity: 0.4;
       cursor: default;
+      display: none;
     }
 
     span {
@@ -126,14 +119,11 @@
   }
 
   .nav-link {
-    @include respond-to("large") {
-      height: 96px;
-    }
     @include flex-container(column, center, center);
     color: $black;
     border-inline-end: 1px solid $light-border;
     height: 70px;
-    
+
     &:hover {
       background-color: $light-hover;
     }
@@ -145,7 +135,7 @@
 
 .upsell {
   @include flex-container(row, center, center);
-  
+
   @include respond-to("small") {
     font-size: 13px;
   }
@@ -155,6 +145,7 @@
   color: $black;
   background: #efeff1;
   width: 100%;
+  line-height: 1.6rem;
 
   .message {
     padding-top: 16px;
@@ -164,7 +155,7 @@
   }
 
   .logo {
-    background-position: left center; 
+    background-position: left center;
     background-image: url("../img/firefox-logo.svg");
     background-repeat: no-repeat;
     background-size: 24px auto;
@@ -180,11 +171,27 @@
   }
 
   .upsellLink {
-    padding-inline-start: 10px;
-    color: $medium-dark-blue;
+    background: $link-blue;
+    border-radius: 3px;
+    color:$white;
+    font-weight: bold;
+    padding-inline-start: 16px;
+    padding: 6px;
+    transition: background 125ms;
+    white-space: nowrap;
+
+    &:hover,
+    &:focus {
+      background: $link-blue-hover;
+    }
+
+    &:active {
+      background: $link-blue-active;
+    }
   }
 
   .signInLink {
-    color: $medium-dark-blue;
+    color: $link-blue;
+    font-weight: bold;
   }
 }

--- a/static/css/partials/_variables.scss
+++ b/static/css/partials/_variables.scss
@@ -13,6 +13,8 @@ $light-border-active: #989898;
 $light-hover: #ededf0;
 $light-active: #dedede;
 $light-default: #f9f9fa;
+$link-blue-active: #003eaa;
+$link-blue-hover: #0060df;
 $link-blue: #0a84ff;
 $active-blue: #45a1ff;
 $link-light: #e1e1e6;

--- a/static/css/settings.scss
+++ b/static/css/settings.scss
@@ -6,9 +6,6 @@
   background-size: $grid-unit $grid-unit;
   background-repeat: no-repeat;
   background-position: center center;
-  position: absolute;
-  inset-inline-end: 0;
-  top: 0;
 
   &:hover {
     background-color: $light-hover;
@@ -25,8 +22,11 @@
 }
 
 #settings-header {
-  margin: 40px auto 15px;
-  position: relative;
+  align-items: flex-end;
+  display: flex;
+  height: 72px;
+  justify-content: flex-end;
+  margin: 0 auto;
 
   @include respond-to("small") {
     width: 380px;
@@ -51,7 +51,7 @@
 
 .preferences {
   margin: auto;
-  padding: 40px 20px 0 20px;
+  padding: 20px 20px 0 20px;
 
   @include respond-to("small") {
     width: 380px;
@@ -85,13 +85,19 @@
 
   .account-info {
     @include flex-container(row, start, center);
+
+    img {
+      border-radius: 50%;
+      box-shadow: $small-box-shadow;
+      overflow: hidden;
+    }
   }
 
   .title {
     font-weight: 500;
     font-size: 17px;
     color: #0c0c0d;
-    margin: 0;
+    margin: 0 0 10px;
   }
 
   .info {

--- a/static/css/shot-index.scss
+++ b/static/css/shot-index.scss
@@ -80,9 +80,9 @@ $shot-width: 210px;
 
 .shot {
   background: $white;
-  box-shadow: $medium-box-shadow;
+  box-shadow: $large-box-shadow;
   margin: 15px;
-  transition: box-shadow 250ms $bezier;
+  transition: box-shadow 250ms;
   width: $shot-width;
 
   .share-panel {
@@ -238,6 +238,8 @@ $shot-width: 210px;
     inset-inline-end: 12px;
     top: 12px;
     background-size: 20px 20px;
+    border: 1px solid $light-hover;
+    box-shadow: $small-box-shadow;
   }
 
   .fav-shot {


### PR DESCRIPTION
This PR provides a bunch of papercut fixes to CSS assocated with accounts feature including:

* Hiding disabled buttons on shot page
* fixing layout nits on settings page when user has avatar of username specified in FxA
* fixes annotation feature so that preview image is at same height
* fixes spacing and layout of upsell ui
* adds a bit of depth to the favorite icon on the shot index page
* fixes the positioning of the shot title editor
* flips the order of the save cancel buttons in editor view to match other button layouts
* Improves spacing of shot subtitles on shot page