### PR TITLE
Reduce metrics

### DIFF
--- a/server/src/ga-activation.js
+++ b/server/src/ga-activation.js
@@ -12,38 +12,8 @@ function _dntEnabled(dnt, ua) {
 
     'use strict';
 
-    // for old version of IE we need to use the msDoNotTrack property of navigator
-    // on newer versions, and newer platforms, this is doNotTrack but, on the window object
-    // Safari also exposes the property on the window object.
-    var dntStatus = dnt || navigator.doNotTrack || window.doNotTrack || navigator.msDoNotTrack;
-    var ua = ua || navigator.userAgent;
-
-    // List of Windows versions known to not implement DNT according to the standard.
-    var anomalousWinVersions = ['Windows NT 6.1', 'Windows NT 6.2', 'Windows NT 6.3'];
-
-    var fxMatch = ua.match(/Firefox\\/(\\d{1,10})/);
-    var ieRegEx = /MSIE|Trident/i;
-    var isIE = ieRegEx.test(ua);
-    // Matches from Windows up to the first occurance of ; un-greedily
-    // http://www.regexr.com/3c2el
-    var platform = ua.match(/Windows.+?(?=;)/g);
-
-    // With old versions of IE, DNT did not exist so we simply return false;
-    if (isIE && typeof Array.prototype.indexOf !== 'function') {
-        return false;
-    } else if (fxMatch && parseInt(fxMatch[1], 10) < 32) {
-        // Can't say for sure if it is 1 or 0, due to Fx bug 887703
-        dntStatus = 'Unspecified';
-    } else if (isIE && platform && anomalousWinVersions.indexOf(platform.toString()) !== -1) {
-        // default is on, which does not honor the specification
-        dntStatus = 'Unspecified';
-    } else {
-        // sets dntStatus to Disabled or Enabled based on the value returned by the browser.
-        // If dntStatus is undefined, it will be set to Unspecified
-        dntStatus = { '0': 'Disabled', '1': 'Enabled' }[dntStatus] || 'Unspecified';
-    }
-
-    return dntStatus === 'Enabled' ? true : false;
+    // Disable GA.
+    return true;
 }
 `;
 

--- a/webextension/background/analytics.js
+++ b/webextension/background/analytics.js
@@ -74,57 +74,6 @@ this.analytics = (function() {
   }
 
   exports.sendEvent = function(action, label, options) {
-    const eventCategory = "addon";
-    if (!telemetryPrefKnown) {
-      log.warn("sendEvent called before we were able to refresh");
-      return Promise.resolve();
-    }
-    if (!telemetryEnabled) {
-      log.info(`Cancelled sendEvent ${eventCategory}/${action}/${label || "none"} ${JSON.stringify(options)}`);
-      return Promise.resolve();
-    }
-    measureTiming(action, label);
-    // Internal-only events are used for measuring time between events,
-    // but aren't submitted to GA.
-    if (action === "internal") {
-      return Promise.resolve();
-    }
-    if (typeof label === "object" && (!options)) {
-      options = label;
-      label = undefined;
-    }
-    options = options || {};
-
-    // Don't send events if in private browsing.
-    if (options.incognito) {
-      return Promise.resolve();
-    }
-
-    // Don't include in event data.
-    delete options.incognito;
-
-    const di = deviceInfo();
-    options.applicationName = di.appName;
-    options.applicationVersion = di.addonVersion;
-    const abTests = auth.getAbTests();
-    for (const [gaField, value] of Object.entries(abTests)) {
-      options[gaField] = value;
-    }
-    pendingEvents.push({
-      eventTime: Date.now(),
-      event: eventCategory,
-      action,
-      label,
-      options,
-    });
-    if (!eventsTimeoutHandle) {
-      eventsTimeoutHandle = setTimeout(() => {
-        eventsTimeoutHandle = null;
-        flushEvents();
-      }, EVENT_BATCH_DURATION);
-    }
-    // This function used to return a Promise that was not used at any of the
-    // call sites; doing this simply maintains that interface.
     return Promise.resolve();
   };
 


### PR DESCRIPTION
Here's a low-effort way to shut off the GA pings:
- set the server GA blob to always assume do not track is set to 'true', so that the sendEvent calls will always be stubbed out
- make `sendEvent` a no-op on the addon side, leaving the `incrementCount` function in place to actually send the telemetry data

I think this should work. R?