### PR TITLE
Add a column to /metrics that shows the number of shots that are set to never expire

### DIFF
--- a/server/src/pages/metrics/model.js
+++ b/server/src/pages/metrics/model.js
@@ -8,12 +8,14 @@ const queries = {
     SELECT
         (SELECT COUNT(devices.id) FROM devices) AS total_devices,
         (SELECT COUNT(data.id) FROM data WHERE NOT deleted AND expire_time < CURRENT_TIMESTAMP) AS active_shots,
+        (SELECT COUNT(data.id) FROM data WHERE NOT deleted AND expire_time IS NULL) AS forever_shots,
         (SELECT COUNT(data.id) FROM data WHERE NOT deleted AND expire_time >= CURRENT_TIMESTAMP) AS expired_recoverable_shots,
         (SELECT COUNT(data.id) FROM data WHERE deleted) AS expired_deleted_shots;
     `,
     columns: [
       {title: "Total devices registered", name: "total_devices"},
       {title: "Active shots", name: "active_shots"},
+      {title: "Never expiring shots", name: "forever_shots"},
       {title: "Expired (recoverable)", name: "expired_recoverable_shots"},
       {title: "... (deleted)", name: "expired_deleted_shots"},
     ],


### PR DESCRIPTION
We did this ad hoc, but I'd written code to add it to /metrics already, so...