### PR TITLE
Fix #5247, put shutdown placeholder page in place

### DIFF
--- a/server/src/pages/hosting-shutdown/model.js
+++ b/server/src/pages/hosting-shutdown/model.js
@@ -1,0 +1,5 @@
+exports.createModel = function(req) {
+  return {
+    title: "shutdown" /* req.getText("shutdownPageTitle") */,
+  };
+};

--- a/server/src/pages/hosting-shutdown/page.js
+++ b/server/src/pages/hosting-shutdown/page.js
@@ -1,0 +1,8 @@
+const { Page } = require("../../reactruntime");
+const viewModule = require("./view");
+
+exports.page = new Page({
+  dir: __dirname,
+  viewModule,
+  noBrowserJavascript: true,
+});

--- a/server/src/pages/hosting-shutdown/server.js
+++ b/server/src/pages/hosting-shutdown/server.js
@@ -1,0 +1,6 @@
+const reactrender = require("../../reactrender");
+
+exports.app = function(req, res) {
+  const page = require("./page").page;
+  reactrender.render(req, res, page);
+};

--- a/server/src/pages/hosting-shutdown/view.js
+++ b/server/src/pages/hosting-shutdown/view.js
@@ -1,0 +1,50 @@
+const reactruntime = require("../../reactruntime");
+const { Footer } = require("../../footer-view.js");
+// const { Localized } = require("fluent-react/compat");
+const React = require("react");
+const PropTypes = require("prop-types");
+const { Header } = require("../../header.js");
+
+class Head extends React.Component {
+  render() {
+    return (
+      <reactruntime.HeadTemplate {...this.props}>
+        <link rel="stylesheet" href={this.props.staticLink("/static/css/shot-index.css")} />
+      </reactruntime.HeadTemplate>
+    );
+  }
+}
+
+Head.propTypes = {
+  staticLink: PropTypes.func,
+};
+
+class Body extends React.Component {
+
+  render() {
+    return (
+      <reactruntime.BodyTemplate {...this.props}>
+        <div className="column-space full-height">
+          <Header hasLogo={true} hasFxa={this.props.hasFxa} />
+          <div id="shot-index" className="flex-1">
+            <div className="no-shots" key="no-shots-found">
+              { /* <Localized id="shutdownPageIntro"> */ }
+                <h1>Hosting shutdown notice.</h1>
+              { /* </Localized> */ }
+              { /* <Localized id="shutdownPageDescription"> */ }
+                <p>We will be discontinuing hosted screenshots. You will still be able to download and copy screenshots in Firefox.</p>
+              { /* </Localized> */ }
+            </div>
+          </div>
+          <Footer {...this.props} />
+        </div>
+      </reactruntime.BodyTemplate>
+    );
+  }
+}
+
+Body.propTypes = {
+};
+
+exports.HeadFactory = React.createFactory(Head);
+exports.BodyFactory = React.createFactory(Body);

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -1268,6 +1268,8 @@ app.use("/creating", require("./pages/creating/server").app);
 
 app.use("/settings", require("./pages/settings/server").app);
 
+app.use("/hosting-shutdown", require("./pages/hosting-shutdown/server").app);
+
 app.use("/", require("./pages/shot/server").app);
 
 app.use("/", require("./pages/homepage/server").app);


### PR DESCRIPTION
This uses /hosting-shutdown, to try to make it clear that only the server is going away, not the other aspects of the product.

The text isn't localized because it isn't written yet, but localization routines are commented-out in the code.

The page looks like this:

<img width="1265" alt="image" src="https://user-images.githubusercontent.com/44390/50613521-65176180-0ea3-11e9-8148-aa5390805f6a.png">

There is a followup for text/localization in #5275