### PR TITLE
Fix #5244, use incognito: spanning in manifest

### DIFF
--- a/webextension/manifest.json.template
+++ b/webextension/manifest.json.template
@@ -5,6 +5,7 @@
   "description": "__MSG_addonDescription__",
   "author": "__MSG_addonAuthorsList__",
   "homepage_url": "https://github.com/mozilla-services/screenshots",
+  "incognito": "spanning",
   "applications": {
     "gecko": {
       "id": "screenshots@mozilla.org",


### PR DESCRIPTION
Soon Firefox will disable add-ons without this, or require people to opt-in

I believe this follows @mixedpuppy's recommendation